### PR TITLE
better Ptr support for plugins' struct{}

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -920,6 +920,9 @@ func (self DefaultAssociative) Associative(scope *Scope, a Any, b Any) (res Any,
 				if field_value.Kind() == reflect.Ptr && field_value.IsNil() {
 					return &Null{}, true
 				}
+				if field_value.Kind() == reflect.Ptr {
+					field_value = field_value.Elem()
+				}
 				return field_value.Interface(), true
 			}
 		}


### PR DESCRIPTION
The pointer value in a structure that is returned as `vfilter.Row` in an output channel does not work well within Scope. 
If you have an output structure in a plugin like this(from the example): 
```
type FileInfo struct {
	Path *string
	Stat os.FileInfo
}
```
the Path field will not be accessible within multiple queries or foreach. 
A small change in `DefaultAssociative` method can solve it. Hope it is helpful. 