### PR TITLE
Scope AddDestructor may fail if destructors were already run.

### DIFF
--- a/scope/scope.go
+++ b/scope/scope.go
@@ -2,6 +2,7 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -460,15 +461,16 @@ func (self *Scope) Trace(format string, a ...interface{}) {
 
 // Adding a destructor to the current scope will call it when any
 // parent scopes are closed.
-func (self *Scope) AddDestructor(fn func()) {
+func (self *Scope) AddDestructor(fn func()) error {
 	self.Lock()
-	defer self.Unlock()
+	self.Unlock()
 
 	// Scope is already destroyed - call the destructor now.
 	if self.destructors.is_destroyed {
-		fn()
+		return errors.New("Scope already closed")
 	} else {
 		self.destructors.fn = append(self.destructors.fn, fn)
+		return nil
 	}
 }
 

--- a/types/scope.go
+++ b/types/scope.go
@@ -65,8 +65,9 @@ type Scope interface {
 	GetSimilarPlugins(name string) []string
 	Describe(type_map *TypeMap) *ScopeInformation
 
-	// Destructors are called when the scope is Close()
-	AddDestructor(fn func())
+	// Destructors are called when the scope is Close(). If the
+	// scope is already closed adding the destructor may fail.
+	AddDestructor(fn func()) error
 	Close()
 
 	// Resolve a variable


### PR DESCRIPTION
We can not guarantee destructors will run if a scope is already
closed.