### PR TITLE
Support ''' strings

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -410,5 +410,11 @@
     {
       "RootEnv.Eval": true
     }
+  ],
+  "034/000 Multiline string constants: LET X='''This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\n''' + \"A string\"": null,
+  "034/001 Multiline string constants: SELECT X FROM scope()": [
+    {
+      "X": "This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\nA string"
+    }
   ]
 }

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -774,6 +774,16 @@ LET Foo = SELECT 2 FROM scope() WHERE set_env(column="Eval", value=TRUE)
 LET result <= if(condition=TRUE, then=Foo) -- should materialize
 SELECT RootEnv.Eval FROM scope()  -- should be set
 `},
+
+	// Multiline string constants
+	{"Multiline string constants", `LET X = '''This
+is
+a
+multiline with 'quotes' and "double quotes" and \ backslashes
+''' + "A string"
+
+SELECT X FROM scope()
+`},
 }
 
 type _RangeArgs struct {


### PR DESCRIPTION
Quoting a string with triple single quote ''' prevents escaping of
backslashes and allows multiline input. This makes it easier to deal
with windows style paths:

SELECT * FROM glob(globs='''C:\Windows\System32\**''')