### PR TITLE
Optimized arg parser.

### DIFF
--- a/arg_parser/cache.go
+++ b/arg_parser/cache.go
@@ -1,0 +1,34 @@
+package arg_parser
+
+import (
+	"reflect"
+	"sync"
+)
+
+var (
+	// A Global cache of parsers and types. These are not expected
+	// to ever change since they are tied to types within the
+	// actual code.
+	mu          sync.Mutex
+	parserCache = make(map[reflect.Type]*Parser)
+)
+
+func GetParser(target reflect.Value) (*Parser, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	t := target.Type()
+
+	parser, pres := parserCache[t]
+	if pres {
+		//fmt.Printf("Cache hit for %v\n", t)
+		return parser, nil
+	}
+
+	parser, err := BuildParser(target)
+	if err != nil {
+		return nil, err
+	}
+	parserCache[t] = parser
+	return parser, nil
+}

--- a/arg_parser/fixtures/args.golden
+++ b/arg_parser/fixtures/args.golden
@@ -1,47 +1,47 @@
 {
-  "000/000 Parse basic types: SELECT parse(int=1, string='hello') FROM scope()": [
+  "000/000 Parse basic types: SELECT parse(r=1, int=1, string='hello') FROM scope()": [
     {
-      "parse(int=1, string='hello')": {
+      "parse(r=1, int=1, string='hello')": {
         "int": 1,
         "string": "hello"
       }
     }
   ],
   "001/000 Parse basic types: LET X=5": null,
-  "001/001 Parse basic types: SELECT parse(int=X) FROM scope()": [
+  "001/001 Parse basic types: SELECT parse(r=1, int=X) FROM scope()": [
     {
-      "parse(int=X)": {
+      "parse(r=1, int=X)": {
         "int": 5
       }
     }
   ],
   "002/000 Parse basic types with param: LET Foo(X)=1 + X": null,
-  "002/001 Parse basic types with param: SELECT parse(int=Foo(X=2)) FROM scope()": [
+  "002/001 Parse basic types with param: SELECT parse(r=1, int=Foo(X=2)) FROM scope()": [
     {
-      "parse(int=Foo(X=2))": {
+      "parse(r=1, int=Foo(X=2))": {
         "int": 3
       }
     }
   ],
   "003/000 Passing Stored query to int field: LET Foo=SELECT 1 FROM scope()": null,
-  "003/001 Passing Stored query to int field: SELECT parse(int=Foo) FROM scope()": [
+  "003/001 Passing Stored query to int field: SELECT parse(r=1, int=Foo) FROM scope()": [
     {
-      "parse(int=Foo)": {
-        "ParseError": "Field Int should be an int."
+      "parse(r=1, int=Foo)": {
+        "ParseError": "Field int should be an int."
       }
     }
   ],
   "004/000 Passing string to int field: LET Foo=\"Hello\"": null,
-  "004/001 Passing string to int field: SELECT parse(int=Foo) FROM scope()": [
+  "004/001 Passing string to int field: SELECT parse(r=1, int=Foo) FROM scope()": [
     {
-      "parse(int=Foo)": {
-        "ParseError": "Field Int should be an int."
+      "parse(r=1, int=Foo)": {
+        "ParseError": "Field int should be an int."
       }
     }
   ],
-  "005/000 String Array: SELECT parse(string_array= [\"X\", \"Y\"]) FROM scope()": [
+  "005/000 String Array: SELECT parse(r=1, string_array= [\"X\", \"Y\"]) FROM scope()": [
     {
-      "parse(string_array= [\"X\", \"Y\"])": {
+      "parse(r=1, string_array= [\"X\", \"Y\"])": {
         "string_array": [
           "X",
           "Y"
@@ -49,27 +49,27 @@
       }
     }
   ],
-  "006/000 String Array with single field: SELECT parse(string_array=\"Hello\") FROM scope()": [
+  "006/000 String Array with single field: SELECT parse(r=1, string_array=\"Hello\") FROM scope()": [
     {
-      "parse(string_array=\"Hello\")": {
+      "parse(r=1, string_array=\"Hello\")": {
         "string_array": [
           "Hello"
         ]
       }
     }
   ],
-  "007/000 String Array getting int array stringifies it: SELECT parse(string_array= [1, ]) FROM scope()": [
+  "007/000 String Array getting int array stringifies it: SELECT parse(r=1, string_array= [1, ]) FROM scope()": [
     {
-      "parse(string_array= [1, ])": {
+      "parse(r=1, string_array= [1, ])": {
         "string_array": [
           "1"
         ]
       }
     }
   ],
-  "008/000 String Array getting int stringifies it: SELECT parse(string_array=1) FROM scope()": [
+  "008/000 String Array getting int stringifies it: SELECT parse(r=1, string_array=1) FROM scope()": [
     {
-      "parse(string_array=1)": {
+      "parse(r=1, string_array=1)": {
         "string_array": [
           "1"
         ]
@@ -77,9 +77,9 @@
     }
   ],
   "009/000 String Array with single field: LET Foo=\"Hello\"": null,
-  "009/001 String Array with single field: SELECT parse(string_array=Foo) FROM scope()": [
+  "009/001 String Array with single field: SELECT parse(r=1, string_array=Foo) FROM scope()": [
     {
-      "parse(string_array=Foo)": {
+      "parse(r=1, string_array=Foo)": {
         "string_array": [
           "Hello"
         ]
@@ -87,9 +87,9 @@
     }
   ],
   "010/000 String Array with stored query expanding a row: LET Foo=SELECT \"Hello\" AS X FROM scope()": null,
-  "010/001 String Array with stored query expanding a row: SELECT parse(string_array=Foo.X) FROM scope()": [
+  "010/001 String Array with stored query expanding a row: SELECT parse(r=1, string_array=Foo.X) FROM scope()": [
     {
-      "parse(string_array=Foo.X)": {
+      "parse(r=1, string_array=Foo.X)": {
         "string_array": [
           "Hello"
         ]
@@ -97,9 +97,9 @@
     }
   ],
   "011/000 String Array with stored query expanding a row of ints: LET Foo=SELECT 1 AS X FROM scope()": null,
-  "011/001 String Array with stored query expanding a row of ints: SELECT parse(string_array=Foo.X) FROM scope()": [
+  "011/001 String Array with stored query expanding a row of ints: SELECT parse(r=1, string_array=Foo.X) FROM scope()": [
     {
-      "parse(string_array=Foo.X)": {
+      "parse(r=1, string_array=Foo.X)": {
         "string_array": [
           "1"
         ]
@@ -107,9 +107,9 @@
     }
   ],
   "012/000 Lazy expressions: LET lazy_expr=1": null,
-  "012/001 Lazy expressions: SELECT parse(lazy=lazy_expr) FROM scope()": [
+  "012/001 Lazy expressions: SELECT parse(r=1, lazy=lazy_expr) FROM scope()": [
     {
-      "parse(lazy=lazy_expr)": {
+      "parse(r=1, lazy=lazy_expr)": {
         "Lazy type": "*vfilter.LazyExprImpl",
         "Lazy Reduced Type": "int64",
         "Lazy Reduced": 1
@@ -117,9 +117,9 @@
     }
   ],
   "013/000 Lazy expressions with parameters: LET lazy_expr(X)=X + 1": null,
-  "013/001 Lazy expressions with parameters: SELECT parse(lazy=lazy_expr(X=1)) FROM scope()": [
+  "013/001 Lazy expressions with parameters: SELECT parse(r=1, lazy=lazy_expr(X=1)) FROM scope()": [
     {
-      "parse(lazy=lazy_expr(X=1))": {
+      "parse(r=1, lazy=lazy_expr(X=1))": {
         "Lazy type": "*vfilter.LazyExprImpl",
         "Lazy Reduced Type": "int64",
         "Lazy Reduced": 2
@@ -127,9 +127,9 @@
     }
   ],
   "014/000 Lazy expressions of stored query: LET query=SELECT 1 FROM scope()": null,
-  "014/001 Lazy expressions of stored query: SELECT parse(lazy=query) FROM scope()": [
+  "014/001 Lazy expressions of stored query: SELECT parse(r=1, lazy=query) FROM scope()": [
     {
-      "parse(lazy=query)": {
+      "parse(r=1, lazy=query)": {
         "Lazy type": "*vfilter.LazyExprImpl",
         "Lazy Reduced Type": "*vfilter._StoredQuery",
         "Lazy Reduced": {},
@@ -143,9 +143,9 @@
   ],
   "015/000 Lazy expressions of stored query with parameters: LET X=5": null,
   "015/001 Lazy expressions of stored query with parameters: LET query(X)=SELECT X FROM scope()": null,
-  "015/002 Lazy expressions of stored query with parameters: SELECT parse(lazy=query(X=2)) FROM scope()": [
+  "015/002 Lazy expressions of stored query with parameters: SELECT parse(r=1, lazy=query(X=2)) FROM scope()": [
     {
-      "parse(lazy=query(X=2))": {
+      "parse(r=1, lazy=query(X=2))": {
         "Lazy type": "*vfilter.LazyExprImpl",
         "Lazy Reduced Type": "*vfilter.StoredQueryCallSite",
         "Lazy Reduced": {},
@@ -158,9 +158,9 @@
     }
   ],
   "016/000 Stored query: LET query=SELECT 1 FROM scope()": null,
-  "016/001 Stored query: SELECT parse(query=query) FROM scope()": [
+  "016/001 Stored query: SELECT parse(r=1, query=query) FROM scope()": [
     {
-      "parse(query=query)": {
+      "parse(r=1, query=query)": {
         "StoredQuery Materialized": [
           {
             "1": 1
@@ -171,9 +171,9 @@
   ],
   "017/000 Stored query with parameters: LET X=5": null,
   "017/001 Stored query with parameters: LET query(X)=SELECT X FROM scope()": null,
-  "017/002 Stored query with parameters: SELECT parse(query=query(X=2)) FROM scope()": [
+  "017/002 Stored query with parameters: SELECT parse(r=1, query=query(X=2)) FROM scope()": [
     {
-      "parse(query=query(X=2))": {
+      "parse(r=1, query=query(X=2))": {
         "StoredQuery Materialized": [
           {
             "X": 2
@@ -182,9 +182,9 @@
       }
     }
   ],
-  "018/000 Stored query given a constant: SELECT parse(query=\"hello\") FROM scope()": [
+  "018/000 Stored query given a constant: SELECT parse(r=1, query=\"hello\") FROM scope()": [
     {
-      "parse(query=\"hello\")": {
+      "parse(r=1, query=\"hello\")": {
         "StoredQuery Materialized": [
           {
             "_value": "hello"
@@ -193,9 +193,9 @@
       }
     }
   ],
-  "019/000 Stored query given a dict: SELECT parse(query=dict(X=\"hello\")) FROM scope()": [
+  "019/000 Stored query given a dict: SELECT parse(r=1, query=dict(X=\"hello\")) FROM scope()": [
     {
-      "parse(query=dict(X=\"hello\"))": {
+      "parse(r=1, query=dict(X=\"hello\"))": {
         "StoredQuery Materialized": [
           {
             "X": "hello"
@@ -205,9 +205,9 @@
     }
   ],
   "020/000 Stored query given an expression: LET X=1": null,
-  "020/001 Stored query given an expression: SELECT parse(query=X) FROM scope()": [
+  "020/001 Stored query given an expression: SELECT parse(r=1, query=X) FROM scope()": [
     {
-      "parse(query=X)": {
+      "parse(r=1, query=X)": {
         "StoredQuery Materialized": [
           {
             "_value": 1
@@ -217,27 +217,27 @@
     }
   ],
   "021/000 Any type: LET X=1": null,
-  "021/001 Any type: SELECT parse(any=X) FROM scope()": [
+  "021/001 Any type: SELECT parse(r=1, any=X) FROM scope()": [
     {
-      "parse(any=X)": {
+      "parse(r=1, any=X)": {
         "any": 1,
         "any type": "int64"
       }
     }
   ],
   "022/000 Any type: LET Foo(X)=X + 1": null,
-  "022/001 Any type: SELECT parse(any=Foo(X=1)) FROM scope()": [
+  "022/001 Any type: SELECT parse(r=1, any=Foo(X=1)) FROM scope()": [
     {
-      "parse(any=Foo(X=1))": {
+      "parse(r=1, any=Foo(X=1))": {
         "any": 2,
         "any type": "int64"
       }
     }
   ],
   "023/000 Any type: LET query=SELECT 1 FROM scope()": null,
-  "023/001 Any type: SELECT parse(any=query) FROM scope()": [
+  "023/001 Any type: SELECT parse(r=1, any=query) FROM scope()": [
     {
-      "parse(any=query)": {
+      "parse(r=1, any=query)": {
         "any": {},
         "any type": "*vfilter._StoredQuery",
         "Any stored query": [
@@ -245,6 +245,20 @@
             "1": 1
           }
         ]
+      }
+    }
+  ],
+  "024/000 Unexpected args: SELECT parse(r=1, int=1, foobar=2) FROM scope()": [
+    {
+      "parse(r=1, int=1, foobar=2)": {
+        "ParseError": "Unexpected arg foobar"
+      }
+    }
+  ],
+  "025/000 Required args: SELECT parse() FROM scope()": [
+    {
+      "parse()": {
+        "ParseError": "Field r is required"
       }
     }
   ]

--- a/arg_parser/parser.go
+++ b/arg_parser/parser.go
@@ -1,0 +1,329 @@
+package arg_parser
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Velocidex/ordereddict"
+	errors "github.com/pkg/errors"
+	"www.velocidex.com/golang/vfilter/types"
+	"www.velocidex.com/golang/vfilter/utils"
+)
+
+type tmpTypes struct {
+	any    types.Any
+	stored types.StoredQuery
+	lazy   types.LazyExpr
+}
+
+var (
+	// A bit of a hack to get the type of interface fields
+	testType        = tmpTypes{}
+	anyType         = reflect.ValueOf(testType).Type().Field(0).Type
+	storedQueryType = reflect.ValueOf(testType).Type().Field(1).Type
+	lazyExprType    = reflect.ValueOf(testType).Type().Field(2).Type
+)
+
+// Structs may tag fields with this name to control parsing.
+const tagName = "vfilter"
+
+type FieldParser struct {
+	Field    string
+	FieldIdx int
+	Required bool
+	Parser   func(scope types.Scope, value interface{}) (interface{}, error)
+}
+
+type Parser struct {
+	Fields []*FieldParser
+}
+
+func (self *Parser) Parse(scope types.Scope, args *ordereddict.Dict, target reflect.Value) error {
+	parsed := make([]string, 0, args.Len())
+
+	for _, parser := range self.Fields {
+		value, pres := args.Get(parser.Field)
+		if !pres {
+			if parser.Required {
+				return fmt.Errorf("Field %s is required", parser.Field)
+			}
+			continue
+		}
+
+		// Keep track of the fields we parsed.
+		parsed = append(parsed, parser.Field)
+
+		// Convert the value using the parser
+		new_value, err := parser.Parser(scope, value)
+		if err != nil {
+			return fmt.Errorf("Field %s %w", parser.Field, err)
+		}
+
+		// Now set the field on the struct.
+		field_value := target.Field(parser.FieldIdx)
+		field_value.Set(reflect.ValueOf(new_value))
+	}
+
+	// Something is wrong! We did not extract all the fields from
+	// the args, there may be unexpected args.
+	if len(parsed) != args.Len() {
+		// Slow path should only be taken on error.
+		for _, key := range args.Keys() {
+			if !utils.InString(&parsed, key) {
+				return fmt.Errorf("Unexpected arg %v", key)
+			}
+		}
+	}
+
+	return nil
+}
+
+func lazyExprParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	return ToLazyExpr(scope, arg), nil
+}
+
+func storedQueryParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	return ToStoredQuery(arg), nil
+}
+
+func anyParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	return arg, nil
+}
+
+func sliceParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	new_value, pres := _ExtractStringArray(scope, arg)
+	if pres {
+		return new_value, nil
+	}
+	return []interface{}{}, nil
+}
+
+func stringParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	// If we expect a string and we get an array
+	// of length 1 of strings, we just take the
+	// first element. This allows us to simply
+	// coerce a query into a variable without
+	// using get.
+	if utils.IsArray(arg) {
+		new_value, pres := _ExtractStringArray(scope, arg)
+		if pres && len(new_value) == 1 {
+			return new_value[0], nil
+		}
+	}
+
+	switch t := arg.(type) {
+	case string:
+		return t, nil
+
+	case types.Null, *types.Null, nil:
+		return "", nil
+	default:
+		return fmt.Sprintf("%s", arg), nil
+	}
+}
+
+func boolParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	return scope.Bool(arg), nil
+}
+
+func floatParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	a, ok := utils.ToFloat(arg)
+	if ok {
+		return a, nil
+	}
+	return nil, errors.New(fmt.Sprintf("Should be a float not %t.", arg))
+}
+
+func int64Parser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	a, ok := utils.ToInt64(arg)
+	if ok {
+		return a, nil
+	}
+	return nil, errors.New("Should be an int.")
+}
+
+func uInt64Parser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	a, ok := utils.ToInt64(arg)
+	if ok {
+		return uint64(a), nil
+	}
+	return nil, errors.New("Should be an int.")
+}
+
+func intParser(scope types.Scope, arg interface{}) (interface{}, error) {
+	lazy_arg, ok := arg.(types.LazyExpr)
+	if ok {
+		arg = lazy_arg.Reduce()
+	}
+
+	a, ok := utils.ToInt64(arg)
+	if ok {
+		return int(a), nil
+	}
+	return nil, errors.New("should be an int.")
+}
+
+// Builds a cacheable parser that can parse into
+func BuildParser(v reflect.Value) (*Parser, error) {
+	t := v.Type()
+
+	if t.Kind() != reflect.Struct {
+		return nil, errors.New("Only structs can be set with ExtractArgs()")
+	}
+
+	result := &Parser{}
+
+	for i := 0; i < v.NumField(); i++ {
+		// Get the field tag value
+		field_types_value := t.Field(i)
+
+		tag := field_types_value.Tag.Get(tagName)
+
+		// Skip if tag is not defined or ignored
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		directives := strings.Split(tag, ",")
+		options := make(map[string]string)
+		for _, directive := range directives {
+			if strings.Contains(directive, "=") {
+				components := strings.Split(directive, "=")
+				if len(components) >= 2 {
+					options[components[0]] = components[1]
+				}
+			} else {
+				options[directive] = "Y"
+			}
+		}
+
+		// Is the name specified in the tag?
+		field_name, pres := options["field"]
+		if !pres {
+			field_name = field_types_value.Name
+		}
+
+		if field_name == "" {
+			panic("Fields can not be empty")
+		}
+
+		_, required := options["required"]
+		field_parser := &FieldParser{
+			Field:    field_name,
+			FieldIdx: i,
+			Required: required,
+		}
+		result.Fields = append(result.Fields, field_parser)
+
+		// Now figure out the required type that will go into
+		// the value output struct field.
+		field_value := v.Field(field_types_value.Index[0])
+		if !field_value.IsValid() || !field_value.CanSet() {
+			return nil, errors.New(fmt.Sprintf(
+				"Field %s is unsettable.", field_name))
+		}
+
+		// The plugin may specify the arg as being a LazyExpr,
+		// in which case it is completely up to it to evaluate
+		// the expression (if at all).  Note: Reducing the
+		// lazy expression may yield a StoredQuery - it is up
+		// to the plugin to handle this case! Generally every
+		// LazyExpr.Reduce() must be followed by a StoredQuery
+		// check. The plugin may then choose to either iterate
+		// over each StoredQuery row, or materialize the
+		// StoredQuery into memory (not recommended).
+		if field_types_value.Type == lazyExprType {
+			// It is not a types.LazyExpr, we wrap it in one.
+			field_parser.Parser = lazyExprParser
+			continue
+		}
+
+		// The target field is a types.StoredQuery - check that what
+		// was provided is actually one of those.
+		if field_types_value.Type == storedQueryType {
+			field_parser.Parser = storedQueryParser
+			continue
+		}
+
+		// The target field is an types.Any type - just assign it directly.
+		if field_types_value.Type == anyType {
+			field_parser.Parser = anyParser
+			continue
+		}
+
+		// Supported target field types:
+		switch field_types_value.Type.Kind() {
+
+		// It is a slice.
+		case reflect.Slice:
+			field_parser.Parser = sliceParser
+			continue
+
+		case reflect.String:
+			field_parser.Parser = stringParser
+			continue
+
+		case reflect.Bool:
+			field_parser.Parser = boolParser
+			continue
+
+		case reflect.Float64:
+			field_parser.Parser = floatParser
+			continue
+
+		case reflect.Int64:
+			field_parser.Parser = int64Parser
+			continue
+
+		case reflect.Uint64:
+			field_parser.Parser = uInt64Parser
+			continue
+
+		case reflect.Int:
+			field_parser.Parser = intParser
+			continue
+
+		default:
+			return nil, fmt.Errorf("Unsupported type for field %v", field_name)
+		}
+
+	}
+
+	return result, nil
+}

--- a/benchmarks/benchmark.txt
+++ b/benchmarks/benchmark.txt
@@ -2,10 +2,10 @@ goos: linux
 goarch: amd64
 pkg: www.velocidex.com/golang/vfilter/benchmarks
 BenchmarkRange10k
-BenchmarkRange10k-16                 	      12	 467982331 ns/op
+BenchmarkRange10k-16                 	      13	 426461168 ns/op
 BenchmarkForeach10k
-BenchmarkForeach10k-16               	       5	1235509232 ns/op
+BenchmarkForeach10k-16               	       5	1164333674 ns/op
 BenchmarkForeachWithWorkers10k
-BenchmarkForeachWithWorkers10k-16    	      18	 320607195 ns/op
+BenchmarkForeachWithWorkers10k-16    	      14	 366238656 ns/op
 PASS
-ok  	www.velocidex.com/golang/vfilter/benchmarks	24.570s
+ok  	www.velocidex.com/golang/vfilter/benchmarks	23.211s

--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -124,9 +124,9 @@
       "X": "Hello world"
     }
   ],
-  "011/000 Serialization: SELECT panic(value=1, colume='X'), func_foo() FROM scope()": [
+  "011/000 Serialization (Unexpected arg aborts parsing): SELECT panic(value=1, column=1, colume='X'), func_foo() FROM scope()": [
     {
-      "panic(value=1, colume='X')": 1,
+      "panic(value=1, column=1, colume='X')": null,
       "func_foo()": 1
     }
   ],

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	golang.org/x/text v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -291,7 +291,8 @@ func (self PanicFunction) Call(ctx context.Context, scope types.Scope, args *ord
 
 	err := ExtractArgs(scope, args, &arg)
 	if err != nil {
-		panic(err)
+		scope.Log("Panic: %v", err)
+		return types.Null{}
 	}
 
 	if scope.Eq(arg.Value, arg.Column) {
@@ -683,8 +684,8 @@ var multiVQLTest = []vqlTest{
 		"LET X = panic() SELECT 1 + 1 FROM scope()"},
 	{"LET materialize with expression",
 		"LET X <= 'Hello world' SELECT X FROM scope()"},
-	{"Serialization",
-		"SELECT panic(value=1, colume='X'), func_foo() FROM scope()"},
+	{"Serialization (Unexpected arg aborts parsing)",
+		"SELECT panic(value=1, column=1, colume='X'), func_foo() FROM scope()"},
 	{"LET with expression lazy - string concat",
 		"LET X = 'hello' SELECT X + 'world', 'world' + X, 'hello world' =~ X FROM scope()"},
 


### PR DESCRIPTION
No need to parse struct tags at runtime. The change compiles a faster
parser on first access from struct tags and then uses that to parse
the args in future.