### PR TITLE
Added scope.Close() for each scope.Copy().

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -316,6 +316,8 @@ func Materialize(ctx context.Context,
 
 	// Materialize both queries to an array.
 	new_scope := scope.Copy()
+	defer new_scope.Close()
+
 	for item := range stored_query.Eval(ctx, new_scope) {
 		result = append(result, item)
 	}

--- a/lambda.go
+++ b/lambda.go
@@ -48,7 +48,10 @@ func (self *Lambda) Reduce(ctx context.Context, scope types.Scope, parameters []
 	for idx, name := range my_parameters {
 		vars.Set(name, parameters[idx])
 	}
+
 	subscope := scope.Copy().AppendVars(vars)
+	defer subscope.Close()
+
 	return self.Expression.Reduce(ctx, subscope)
 }
 

--- a/plugins/chain.go
+++ b/plugins/chain.go
@@ -41,14 +41,19 @@ func (self _ChainPlugin) Call(
 
 		for _, query := range queries {
 			new_scope := scope.Copy()
+
 			in_chan := query.Eval(ctx, new_scope)
 			for item := range in_chan {
 				select {
 				case <-ctx.Done():
+					new_scope.Close()
 					return
+
 				case output_chan <- item:
 				}
 			}
+
+			new_scope.Close()
 		}
 	}()
 

--- a/plugins/foreach.go
+++ b/plugins/foreach.go
@@ -83,10 +83,12 @@ func (self _ForeachPluginImpl) Call(ctx context.Context,
 					continue
 				}
 
-				// Evaluate the query on a new sub scope. The
-				// query can refer to rows returned by the
-				// "row" query.
+				// Evaluate the query on a new sub
+				// scope. The query can refer to rows
+				// returned by the "row" query.
 				child_scope := scope.Copy()
+				// child_scope is closed in the pool worker.
+
 				child_scope.AppendVars(row_item)
 				pool.RunScope(child_scope)
 			}

--- a/protocols/stored_query.go
+++ b/protocols/stored_query.go
@@ -20,8 +20,12 @@ func (self _StoredQueryAssociative) Associative(
 	var result []types.Any
 	stored_query, ok := a.(types.StoredQuery)
 	if ok {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		new_scope := scope.Copy()
+		defer new_scope.Close()
+
 		from_chan := stored_query.Eval(ctx, new_scope)
 		i := int64(0)
 		int_b, b_is_int := utils.ToInt64(b)
@@ -55,7 +59,10 @@ func (self _StoredQueryBool) Bool(scope types.Scope, a types.Any) bool {
 	if ok {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		new_scope := scope.Copy()
+		defer new_scope.Close()
+
 		from_chan := stored_query.Eval(ctx, new_scope)
 		for {
 			// As soon as a single result is returned we
@@ -98,6 +105,8 @@ func MaterializeToArray(ctx context.Context, scope types.Scope,
 
 	// Materialize both queries to an array.
 	new_scope := scope.Copy()
+	defer new_scope.Close()
+
 	for item := range stored_query.Eval(ctx, new_scope) {
 		result = append(result, item)
 	}

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -248,6 +249,10 @@ func (self *Scope) Copy() types.Scope {
 	}
 
 	// Remember our children.
+	if len(self.children) > 1000 {
+		fmt.Printf("Scopying scope of %v children - this is probably a bug!!!\n%v\n",
+			len(self.children), string(debug.Stack()))
+	}
 	self.children[child_scope] = child_scope
 
 	return child_scope

--- a/scope_test.go
+++ b/scope_test.go
@@ -42,7 +42,11 @@ func (self DestructorFunction) Call(
 	}
 
 	count++
+
+	mu.Lock()
 	markers = append(markers, fmt.Sprintf("Func Open %s %x", arg.Name, count))
+	mu.Unlock()
+
 	scope.AddDestructor(func() {
 		logMarkers("Func Close %s %x", arg.Name, count)
 	})
@@ -194,9 +198,11 @@ func TestDestructors(t *testing.T) {
 		// Close the scope to force destructors to be called.
 		scope.Close()
 
+		mu.Lock()
 		result.Set(fmt.Sprintf(
 			"%03d %s: %s - markers", i, testCase.name, query),
 			markers)
+		mu.Unlock()
 	}
 
 	g := goldie.New(

--- a/stored.go
+++ b/stored.go
@@ -116,6 +116,8 @@ func Materialize(ctx context.Context, scope types.Scope, stored_query StoredQuer
 
 	// Materialize both queries to an array.
 	new_scope := scope.Copy()
+	defer new_scope.Close()
+
 	for item := range stored_query.Eval(ctx, new_scope) {
 		result = append(result, item)
 	}
@@ -149,6 +151,7 @@ func (self *StoredExpression) Call(ctx context.Context,
 	self.checkCallingArgs(scope, args)
 
 	sub_scope := scope.Copy()
+	defer sub_scope.Close()
 
 	vars := ordereddict.NewDict()
 	for _, k := range args.Keys() {

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -338,7 +338,7 @@ func (self SetEnvFunction) Call(ctx context.Context, scope types.Scope, args *or
 	}
 
 	env.Set(arg.Column, arg.Value)
-	return env
+	return true
 }
 func (self SetEnvFunction) Info(scope types.Scope, type_map *TypeMap) *FunctionInfo {
 	return &FunctionInfo{


### PR DESCRIPTION
This fixed a number of memory leaks with group by