### PR TITLE
Revert previous change with types.Any args.

### DIFF
--- a/arg_parser/args_test.go
+++ b/arg_parser/args_test.go
@@ -187,13 +187,13 @@ func (self argFunc) Call(ctx context.Context, scope types.Scope, args *ordereddi
 
 		lazy_expr, ok := arg.Any.(types.LazyExpr)
 		if ok {
-			result.Set("Any lazy expression", lazy_expr.Reduce())
+			result.Set("Any lazy expression", lazy_expr.Reduce(ctx))
 		}
 	}
 
 	if arg.LazyExpr != nil {
 		result.Set("Lazy type", fmt.Sprintf("%T", arg.LazyExpr))
-		reduced := arg.LazyExpr.Reduce()
+		reduced := arg.LazyExpr.Reduce(ctx)
 		result.Set("Lazy Reduced Type", fmt.Sprintf("%T", reduced))
 		result.Set("Lazy Reduced", reduced)
 

--- a/arg_parser/fixtures/args.golden
+++ b/arg_parser/fixtures/args.golden
@@ -220,45 +220,8 @@
   "021/001 Any type: SELECT parse(r=1, any=X) FROM scope()": [
     {
       "parse(r=1, any=X)": {
-        "any": {
-          "Value": 1,
-          "Expr": {
-            "Left": {
-              "Left": {
-                "Not": null,
-                "Left": {
-                  "Left": {
-                    "Left": {
-                      "Left": {
-                        "Negated": false,
-                        "SymbolRef": {
-                          "Symbol": "X",
-                          "Called": false,
-                          "Parameters": null
-                        },
-                        "Subexpression": null,
-                        "String": null,
-                        "StrNumber": null,
-                        "Float": null,
-                        "Int": null,
-                        "Boolean": null,
-                        "Null": false
-                      },
-                      "Right": null
-                    },
-                    "Right": null
-                  },
-                  "Right": null
-                },
-                "Right": null
-              },
-              "Right": null
-            },
-            "Right": null
-          }
-        },
-        "any type": "*vfilter.LazyExprImpl",
-        "Any lazy expression": 1
+        "any": 1,
+        "any type": "int64"
       }
     }
   ],
@@ -266,81 +229,8 @@
   "022/001 Any type: SELECT parse(r=1, any=Foo(X=1)) FROM scope()": [
     {
       "parse(r=1, any=Foo(X=1))": {
-        "any": {
-          "Value": 2,
-          "Expr": {
-            "Left": {
-              "Left": {
-                "Not": null,
-                "Left": {
-                  "Left": {
-                    "Left": {
-                      "Left": {
-                        "Negated": false,
-                        "SymbolRef": {
-                          "Symbol": "Foo",
-                          "Called": true,
-                          "Parameters": [
-                            {
-                              "Left": "X",
-                              "SubSelect": null,
-                              "Array": null,
-                              "Right": {
-                                "Left": {
-                                  "Left": {
-                                    "Not": null,
-                                    "Left": {
-                                      "Left": {
-                                        "Left": {
-                                          "Left": {
-                                            "Negated": false,
-                                            "SymbolRef": null,
-                                            "Subexpression": null,
-                                            "String": null,
-                                            "StrNumber": "1",
-                                            "Float": null,
-                                            "Int": 1,
-                                            "Boolean": null,
-                                            "Null": false
-                                          },
-                                          "Right": null
-                                        },
-                                        "Right": null
-                                      },
-                                      "Right": null
-                                    },
-                                    "Right": null
-                                  },
-                                  "Right": null
-                                },
-                                "Right": null
-                              }
-                            }
-                          ]
-                        },
-                        "Subexpression": null,
-                        "String": null,
-                        "StrNumber": null,
-                        "Float": null,
-                        "Int": null,
-                        "Boolean": null,
-                        "Null": false
-                      },
-                      "Right": null
-                    },
-                    "Right": null
-                  },
-                  "Right": null
-                },
-                "Right": null
-              },
-              "Right": null
-            },
-            "Right": null
-          }
-        },
-        "any type": "*vfilter.LazyExprImpl",
-        "Any lazy expression": 2
+        "any": 2,
+        "any type": "int64"
       }
     }
   ],
@@ -348,45 +238,13 @@
   "023/001 Any type: SELECT parse(r=1, any=query) FROM scope()": [
     {
       "parse(r=1, any=query)": {
-        "any": {
-          "Value": {},
-          "Expr": {
-            "Left": {
-              "Left": {
-                "Not": null,
-                "Left": {
-                  "Left": {
-                    "Left": {
-                      "Left": {
-                        "Negated": false,
-                        "SymbolRef": {
-                          "Symbol": "query",
-                          "Called": false,
-                          "Parameters": null
-                        },
-                        "Subexpression": null,
-                        "String": null,
-                        "StrNumber": null,
-                        "Float": null,
-                        "Int": null,
-                        "Boolean": null,
-                        "Null": false
-                      },
-                      "Right": null
-                    },
-                    "Right": null
-                  },
-                  "Right": null
-                },
-                "Right": null
-              },
-              "Right": null
-            },
-            "Right": null
+        "any": {},
+        "any type": "*vfilter._StoredQuery",
+        "Any stored query": [
+          {
+            "1": 1
           }
-        },
-        "any type": "*vfilter.LazyExprImpl",
-        "Any lazy expression": {}
+        ]
       }
     }
   ],

--- a/fixtures/vql_queries.golden
+++ b/fixtures/vql_queries.golden
@@ -597,14 +597,14 @@
       ]
     }
   ],
-  "067 If function should be lazy: SELECT if(condition=FALSE, then=panic(column=1, value=1)) FROM scope()": [
+  "067 If function should be lazy: SELECT if(condition=FALSE, then=panic(column=2, value=2)) FROM scope()": [
     {
-      "if(condition=FALSE, then=panic(column=1, value=1))": null
+      "if(condition=FALSE, then=panic(column=2, value=2))": null
     }
   ],
-  "068 If function should be lazy: SELECT if(condition=TRUE, else=panic(column=1, value=1)) FROM scope()": [
+  "068 If function should be lazy: SELECT if(condition=TRUE, else=panic(column=7, value=7)) FROM scope()": [
     {
-      "if(condition=TRUE, else=panic(column=1, value=1))": null
+      "if(condition=TRUE, else=panic(column=7, value=7))": null
     }
   ],
   "069 If function should be lazy with sub query: SELECT if(condition=TRUE, then= { SELECT * FROM test() LIMIT 1 }) FROM scope()": [
@@ -617,14 +617,14 @@
       ]
     }
   ],
-  "070 If function should be lazy with sub query: SELECT if(condition=FALSE, then= { SELECT panic(column=1, value=1) FROM test()}) FROM scope()": [
+  "070 If function should be lazy with sub query: SELECT if(condition=FALSE, then= { SELECT panic(column=8, value=8) FROM test()}) FROM scope()": [
     {
-      "if(condition=FALSE, then= { SELECT panic(column=1, value=1) FROM test()})": null
+      "if(condition=FALSE, then= { SELECT panic(column=8, value=8) FROM test()})": null
     }
   ],
-  "071 If function should be lazy: SELECT if(condition=TRUE, else= { SELECT panic(column=1, value=1) FROM test()}) FROM scope()": [
+  "071 If function should be lazy: SELECT if(condition=TRUE, else= { SELECT panic(column=9, value=9) FROM test()}) FROM scope()": [
     {
-      "if(condition=TRUE, else= { SELECT panic(column=1, value=1) FROM test()})": null
+      "if(condition=TRUE, else= { SELECT panic(column=9, value=9) FROM test()})": null
     }
   ],
   "072 If function should be lazy WRT stored query 1/2: LET bomb=SELECT panic(column=1, value=1) FROM scope()": null,

--- a/functions/functions.go
+++ b/functions/functions.go
@@ -35,7 +35,7 @@ func (self _DictFunc) Call(ctx context.Context, scope types.Scope, args *ordered
 		v, _ := args.Get(k)
 		lazy_arg, ok := v.(types.LazyExpr)
 		if ok {
-			result.Set(k, lazy_arg.Reduce())
+			result.Set(k, lazy_arg.Reduce(ctx))
 		} else {
 			result.Set(k, v)
 		}

--- a/lazy.go
+++ b/lazy.go
@@ -132,7 +132,8 @@ func (self *LazyExprImpl) ToString() string {
 	return self.Expr.ToString(self.scope)
 }
 
-func (self *LazyExprImpl) ReduceWithScope(scope types.Scope) types.Any {
+func (self *LazyExprImpl) ReduceWithScope(
+	ctx context.Context, scope types.Scope) types.Any {
 	var result types.Any
 	if self.Expr == nil {
 		result = &Null{}
@@ -150,17 +151,17 @@ func (self *LazyExprImpl) ReduceWithScope(scope types.Scope) types.Any {
 		result = t()
 
 	case types.LazyExpr:
-		result = t.Reduce()
+		result = t.Reduce(ctx)
 	}
 
 	return result
 }
 
-func (self *LazyExprImpl) Reduce() types.Any {
+func (self *LazyExprImpl) Reduce(ctx context.Context) types.Any {
 	if self.Value != nil {
 		return self.Value
 	}
-	self.Value = self.ReduceWithScope(self.scope)
+	self.Value = self.ReduceWithScope(ctx, self.scope)
 	return self.Value
 }
 
@@ -213,7 +214,7 @@ func normalize_value(ctx context.Context, scope Scope, value types.Any, depth in
 
 		// Reduce any LazyExpr to materialized types
 	case types.LazyExpr:
-		return normalize_value(ctx, scope, t.Reduce(), depth+1)
+		return normalize_value(ctx, scope, t.Reduce(ctx), depth+1)
 
 		// Materialize stored queries into an array.
 	case types.StoredQuery:

--- a/plugins/builtins.go
+++ b/plugins/builtins.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"context"
+
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/vfilter/types"
 )
@@ -14,7 +16,8 @@ func GetBuiltinPlugins() []types.PluginGeneratorInterface {
 		RangePlugin{},
 		&GenericListPlugin{
 			PluginName: "scope",
-			Function: func(scope types.Scope, args *ordereddict.Dict) []types.Row {
+			Function: func(ctx context.Context,
+				scope types.Scope, args *ordereddict.Dict) []types.Row {
 				return []types.Row{scope}
 			},
 		},

--- a/plugins/chain.go
+++ b/plugins/chain.go
@@ -35,7 +35,7 @@ func (self _ChainPlugin) Call(
 		for _, member := range members {
 			member_obj, pres := args.Get(member)
 			if pres {
-				queries = append(queries, arg_parser.ToStoredQuery(member_obj))
+				queries = append(queries, arg_parser.ToStoredQuery(ctx, member_obj))
 			}
 		}
 

--- a/plugins/generic.go
+++ b/plugins/generic.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Generic synchronous plugins just return all their rows at once.
-type FunctionPlugin func(scope types.Scope, args *ordereddict.Dict) []types.Row
+type FunctionPlugin func(ctx context.Context, scope types.Scope, args *ordereddict.Dict) []types.Row
 
 // A generic plugin based on a function returning a slice of
 // rows. Many simpler plugins do not need an asynchronous interface
@@ -39,7 +39,7 @@ func (self GenericListPlugin) Call(
 	go func() {
 		defer close(output_chan)
 
-		for _, item := range self.Function(scope, args) {
+		for _, item := range self.Function(ctx, scope, args) {
 			select {
 			case <-ctx.Done():
 				return

--- a/protocols/protocol_bool.go
+++ b/protocols/protocol_bool.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/Velocidex/ordereddict"
@@ -16,7 +17,7 @@ func (self BoolDispatcher) Copy() BoolDispatcher {
 		append([]BoolProtocol{}, self.impl...)}
 }
 
-func (self BoolDispatcher) Bool(scope types.Scope, a types.Any) bool {
+func (self BoolDispatcher) Bool(ctx context.Context, scope types.Scope, a types.Any) bool {
 
 	// Handle directly the built in types for speed.
 	switch t := a.(type) {
@@ -54,7 +55,7 @@ func (self BoolDispatcher) Bool(scope types.Scope, a types.Any) bool {
 		return t.Len() > 0
 
 	case types.LazyExpr:
-		return self.Bool(scope, t.Reduce())
+		return self.Bool(ctx, scope, t.ReduceWithScope(ctx, scope))
 	}
 
 	if is_array(a) {
@@ -65,7 +66,7 @@ func (self BoolDispatcher) Bool(scope types.Scope, a types.Any) bool {
 	for i, impl := range self.impl {
 		if impl.Applicable(a) {
 			scope.GetStats().IncProtocolSearch(i)
-			return impl.Bool(scope, a)
+			return impl.Bool(ctx, scope, a)
 		}
 	}
 
@@ -82,5 +83,5 @@ func (self *BoolDispatcher) AddImpl(elements ...BoolProtocol) {
 // This protocol implements the truth value.
 type BoolProtocol interface {
 	Applicable(a types.Any) bool
-	Bool(scope types.Scope, a types.Any) bool
+	Bool(ctx context.Context, scope types.Scope, a types.Any) bool
 }

--- a/protocols/protocol_iterate.go
+++ b/protocols/protocol_iterate.go
@@ -25,7 +25,7 @@ func (self IterateDispatcher) Iterate(
 
 	// A LazyExpr is a placeholder for a real value.
 	case types.LazyExpr:
-		return scope.Iterate(ctx, t.Reduce())
+		return scope.Iterate(ctx, t.Reduce(ctx))
 
 		// A StoredQuery is a source of rows and so returns a channel.
 	case types.StoredQuery:

--- a/protocols/stored_query.go
+++ b/protocols/stored_query.go
@@ -54,12 +54,9 @@ func (self _StoredQueryAssociative) GetMembers(scope types.Scope, a types.Any) [
 
 type _StoredQueryBool struct{}
 
-func (self _StoredQueryBool) Bool(scope types.Scope, a types.Any) bool {
+func (self _StoredQueryBool) Bool(ctx context.Context, scope types.Scope, a types.Any) bool {
 	stored_query, ok := a.(types.StoredQuery)
 	if ok {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
 		new_scope := scope.Copy()
 		defer new_scope.Close()
 

--- a/scope/dispatcher.go
+++ b/scope/dispatcher.go
@@ -230,7 +230,7 @@ func (self *protocolDispatcher) AddProtocolImpl(implementations ...types.Any) {
 			self.iterator.AddImpl(t)
 		default:
 			utils.Debug(t)
-			panic("Unsupported interface")
+			panic(fmt.Sprintf("Unsupported interface: %T", imp))
 		}
 	}
 }

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -172,7 +172,8 @@ func (self *Scope) Eq(a types.Any, b types.Any) bool {
 
 // Evaluate the truth value of a value.
 func (self *Scope) Bool(a types.Any) bool {
-	return self.dispatcher.bool.Bool(self, a)
+	ctx := context.Background()
+	return self.dispatcher.bool.Bool(ctx, self, a)
 }
 
 // Is a less than b?

--- a/stored.go
+++ b/stored.go
@@ -71,7 +71,7 @@ func (self *_StoredQuery) Call(ctx context.Context,
 		v, _ := args.Get(k)
 		switch t := v.(type) {
 		case types.LazyExpr:
-			v = t.Reduce()
+			v = t.Reduce(ctx)
 		case types.StoredQuery:
 			v = types.Materialize(ctx, scope, t)
 		}
@@ -144,7 +144,7 @@ func (self *StoredExpression) Call(ctx context.Context,
 		v, _ := args.Get(k)
 		switch t := v.(type) {
 		case types.LazyExpr:
-			v = t.Reduce()
+			v = t.Reduce(ctx)
 		case types.StoredQuery:
 			v = types.Materialize(ctx, scope, t)
 		}

--- a/types/lazy.go
+++ b/types/lazy.go
@@ -29,16 +29,8 @@ type Memberer interface {
 // A LazyExpr has a reduce method that allows it to be materialized.
 type LazyExpr interface {
 	// Reduce with the scope captured at point of definition.
-	Reduce() Any
+	Reduce(ctx context.Context) Any
 
 	// Reduce with a new scope.
-	ReduceWithScope(scope Scope) Any
-}
-
-type LazyExprWrapper struct {
-	Value Any
-}
-
-func (self *LazyExprWrapper) Reduce() Any {
-	return self.Value
+	ReduceWithScope(ctx context.Context, scope Scope) Any
 }


### PR DESCRIPTION
Make if() function take a LazyExpr instead, and have LazyExpr wrap
stored queries so they get evaluated with the expression's scope.