### PR TITLE
Overriding a built in func with a variable caused confusion.

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -160,28 +160,20 @@
       "Foo": 1
     }
   ],
-  "015/000 Calling lazy expressions as functions creates a new scope: LET Y=count()": null,
-  "015/001 Calling lazy expressions as functions creates a new scope: SELECT Y AS Y1, Y AS Y2, Y AS Y3 FROM scope()": [
-    {
-      "Y1": 1,
-      "Y2": 2,
-      "Y3": 3
-    }
-  ],
-  "016/000 Defining functions with args: LET X(Foo,Bar)=Foo + Bar": null,
-  "016/001 Defining functions with args: SELECT X(Foo=5, Bar=2) FROM scope()": [
+  "015/000 Defining functions with args: LET X(Foo,Bar)=Foo + Bar": null,
+  "015/001 Defining functions with args: SELECT X(Foo=5, Bar=2) FROM scope()": [
     {
       "X(Foo=5, Bar=2)": 7
     }
   ],
-  "017/000 Defining stored queries with args: LET X(Foo,Bar)=SELECT Foo + Bar FROM scope()": null,
-  "017/001 Defining stored queries with args: SELECT * FROM X(Foo=5, Bar=2)": [
+  "016/000 Defining stored queries with args: LET X(Foo,Bar)=SELECT Foo + Bar FROM scope()": null,
+  "016/001 Defining stored queries with args: SELECT * FROM X(Foo=5, Bar=2)": [
     {
       "Foo + Bar": 7
     }
   ],
-  "018/000 Defining functions masking variable name: LET X(foo)=foo + 2": null,
-  "018/001 Defining functions masking variable name: SELECT X(foo=foo), foo FROM test()": [
+  "017/000 Defining functions masking variable name: LET X(foo)=foo + 2": null,
+  "017/001 Defining functions masking variable name: SELECT X(foo=foo), foo FROM test()": [
     {
       "X(foo=foo)": 2,
       "foo": 0
@@ -195,9 +187,9 @@
       "foo": 4
     }
   ],
-  "019/000 Defining stored queries masking variable name: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
-  "019/001 Defining stored queries masking variable name: LET foo=2": null,
-  "019/002 Defining stored queries masking variable name: SELECT * FROM X(foo=foo)": [
+  "018/000 Defining stored queries masking variable name: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
+  "018/001 Defining stored queries masking variable name: LET foo=2": null,
+  "018/002 Defining stored queries masking variable name: SELECT * FROM X(foo=foo)": [
     {
       "value": 2,
       "foo": 2
@@ -211,8 +203,8 @@
       "foo": 2
     }
   ],
-  "020/000 Calling stored query in function context: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
-  "020/001 Calling stored query in function context: SELECT X(foo=5).value, X(foo=10) FROM scope()": [
+  "019/000 Calling stored query in function context: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
+  "019/001 Calling stored query in function context: SELECT X(foo=5).value, X(foo=10) FROM scope()": [
     {
       "X(foo=5).value": [
         5,
@@ -235,9 +227,9 @@
       ]
     }
   ],
-  "021/000 Calling stored query with args: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
-  "021/001 Calling stored query with args: LET foo=8": null,
-  "021/002 Calling stored query with args: SELECT * FROM foreach(row=X, query= { SELECT *, value FROM X(foo=value)})": [
+  "020/000 Calling stored query with args: LET X(foo)=SELECT *, foo FROM range(start=foo, end=foo + 2)": null,
+  "020/001 Calling stored query with args: LET foo=8": null,
+  "020/002 Calling stored query with args: SELECT * FROM foreach(row=X, query= { SELECT *, value FROM X(foo=value)})": [
     {
       "foo": 8,
       "value": 8
@@ -275,8 +267,8 @@
       "value": 12
     }
   ],
-  "022/000 Lazy expression evaluates in caller's scope: LET X(foo)=1 + foo": null,
-  "022/001 Lazy expression evaluates in caller's scope: SELECT X(foo=foo + 1), foo FROM test()": [
+  "021/000 Lazy expression evaluates in caller's scope: LET X(foo)=1 + foo": null,
+  "021/001 Lazy expression evaluates in caller's scope: SELECT X(foo=foo + 1), foo FROM test()": [
     {
       "X(foo=foo + 1)": 2,
       "foo": 0
@@ -290,56 +282,56 @@
       "foo": 4
     }
   ],
-  "023/000 Calling lazy expressions as functions allows access to global scope: LET Xk=5": null,
-  "023/001 Calling lazy expressions as functions allows access to global scope: LET Y=Xk + count()": null,
-  "023/002 Calling lazy expressions as functions allows access to global scope: SELECT Y AS Y1, Y AS Y2, Y AS Y3 FROM scope()": [
+  "022/000 Calling lazy expressions as functions allows access to global scope: LET Xk=5": null,
+  "022/001 Calling lazy expressions as functions allows access to global scope: LET Y=Xk + count()": null,
+  "022/002 Calling lazy expressions as functions allows access to global scope: SELECT Y AS Y1, Y AS Y2, Y() AS Y3 FROM scope()": [
     {
       "Y1": 6,
       "Y2": 7,
       "Y3": 8
     }
   ],
+  "023/000 Overflow condition - should not get stuck: LET X=1 + X": null,
+  "023/001 Overflow condition - should not get stuck: SELECT X(X=1), X FROM test()": [
+    {
+      "X(X=1)": 2,
+      "X": null
+    },
+    {
+      "X(X=1)": 2,
+      "X": null
+    },
+    {
+      "X(X=1)": 2,
+      "X": null
+    }
+  ],
   "024/000 Overflow condition - should not get stuck: LET X=1 + X": null,
-  "024/001 Overflow condition - should not get stuck: SELECT X(X=1), X FROM test()": [
-    {
-      "X(X=1)": 2,
-      "X": null
-    },
-    {
-      "X(X=1)": 2,
-      "X": null
-    },
-    {
-      "X(X=1)": 2,
-      "X": null
-    }
-  ],
-  "025/000 Overflow condition - should not get stuck: LET X=1 + X": null,
-  "025/001 Overflow condition - should not get stuck: LET Y=1 + Y": null,
-  "025/002 Overflow condition - should not get stuck: SELECT X, Y FROM scope()": [
+  "024/001 Overflow condition - should not get stuck: LET Y=1 + Y": null,
+  "024/002 Overflow condition - should not get stuck: SELECT X, Y FROM scope()": [
     {
       "X": null,
       "Y": null
     }
   ],
-  "026/000 Overflow condition materialized - should not get stuck: LET X\u003c=1 + X": null,
-  "026/001 Overflow condition materialized - should not get stuck: LET Y=1 + Y": null,
-  "026/002 Overflow condition materialized - should not get stuck: SELECT X, Y FROM scope()": [
+  "025/000 Overflow condition materialized - should not get stuck: LET X\u003c=1 + X": null,
+  "025/001 Overflow condition materialized - should not get stuck: LET Y=1 + Y": null,
+  "025/002 Overflow condition materialized - should not get stuck: SELECT X, Y FROM scope()": [
     {
       "X": null,
       "Y": null
     }
   ],
-  "027/000 Overflow with plugins: LET foo_plugin(X)=SELECT * FROM chain(a= { SELECT * FROM foo_plugin(X=1)})": null,
-  "027/001 Overflow with plugins: SELECT * FROM foo_plugin(X=1)": null,
-  "028/000 Escaped identifiers for arg parameters: SELECT dict(`arg-with-special chars`=TRUE) FROM scope()": [
+  "026/000 Overflow with plugins: LET foo_plugin(X)=SELECT * FROM chain(a= { SELECT * FROM foo_plugin(X=1)})": null,
+  "026/001 Overflow with plugins: SELECT * FROM foo_plugin(X=1)": null,
+  "027/000 Escaped identifiers for arg parameters: SELECT dict(`arg-with-special chars`=TRUE) FROM scope()": [
     {
       "dict(`arg-with-special chars`=TRUE)": {
         "arg-with-special chars": true
       }
     }
   ],
-  "029/000 Group by hidden column: SELECT bar, baz FROM groupbytest() GROUP BY bar": [
+  "028/000 Group by hidden column: SELECT bar, baz FROM groupbytest() GROUP BY bar": [
     {
       "bar": 5,
       "baz": "b"
@@ -349,7 +341,7 @@
       "baz": "d"
     }
   ],
-  "029/001 Group by hidden column: SELECT baz FROM groupbytest() GROUP BY bar": [
+  "028/001 Group by hidden column: SELECT baz FROM groupbytest() GROUP BY bar": [
     {
       "baz": "b"
     },
@@ -357,7 +349,7 @@
       "baz": "d"
     }
   ],
-  "030/000 Group by expression: SELECT *, bar + bar FROM groupbytest() GROUP BY bar + bar": [
+  "029/000 Group by expression: SELECT *, bar + bar FROM groupbytest() GROUP BY bar + bar": [
     {
       "foo": 2,
       "bar": 5,
@@ -371,8 +363,8 @@
       "bar + bar": 4
     }
   ],
-  "031/000 Variable can not mask a function.: LET dict(x)=1": null,
-  "031/001 Variable can not mask a function.: SELECT 1 AS dict, dict(foo=1) FROM scope() WHERE dict()": [
+  "030/000 Variable can not mask a function.: LET dict(x)=1": null,
+  "030/001 Variable can not mask a function.: SELECT 1 AS dict, dict(foo=1) FROM scope() WHERE dict": [
     {
       "dict": 1,
       "dict(foo=1)": {
@@ -380,19 +372,19 @@
       }
     }
   ],
-  "032/000 Foreach evals query in row scope (both queries should be same): LET row_query=SELECT 1 AS ColumnName123 FROM scope()": null,
-  "032/001 Foreach evals query in row scope (both queries should be same): LET foreach_query=SELECT ColumnName123 FROM scope()": null,
-  "032/002 Foreach evals query in row scope (both queries should be same): SELECT * FROM foreach(row=row_query, query=foreach_query)": [
+  "031/000 Foreach evals query in row scope (both queries should be same): LET row_query=SELECT 1 AS ColumnName123 FROM scope()": null,
+  "031/001 Foreach evals query in row scope (both queries should be same): LET foreach_query=SELECT ColumnName123 FROM scope()": null,
+  "031/002 Foreach evals query in row scope (both queries should be same): SELECT * FROM foreach(row=row_query, query=foreach_query)": [
     {
       "ColumnName123": 1
     }
   ],
-  "032/003 Foreach evals query in row scope (both queries should be same): SELECT * FROM foreach(row=row_query, query= { SELECT ColumnName123 FROM scope()})": [
+  "031/003 Foreach evals query in row scope (both queries should be same): SELECT * FROM foreach(row=row_query, query= { SELECT ColumnName123 FROM scope()})": [
     {
       "ColumnName123": 1
     }
   ],
-  "033/000 Aggregate functions with multiple evaluations: SELECT count() AS Count FROM foreach(row= [0, 1, 2]) WHERE Count \u003c= 2 AND Count AND Count AND Count AND count() and count()": [
+  "032/000 Aggregate functions with multiple evaluations: SELECT count() AS Count FROM foreach(row= [0, 1, 2]) WHERE Count \u003c= 2 AND Count AND Count AND Count AND count() and count()": [
     {
       "Count": 1
     },
@@ -400,14 +392,14 @@
       "Count": 2
     }
   ],
-  "034/000 Aggregate functions: min max: SELECT min(item=_value) AS Min, max(item=_value) AS Max, count() AS Count FROM foreach(row= [0, 1, 2]) GROUP BY 1": [
+  "033/000 Aggregate functions: min max: SELECT min(item=_value) AS Min, max(item=_value) AS Max, count() AS Count FROM foreach(row= [0, 1, 2]) GROUP BY 1": [
     {
       "Min": 0,
       "Max": 2,
       "Count": 3
     }
   ],
-  "035/000 Aggregate functions keep state per unique instance: SELECT * FROM foreach(row= [0, 1, 2], query= { SELECT count() AS A, count() AS B FROM scope()})": [
+  "034/000 Aggregate functions keep state per unique instance: SELECT * FROM foreach(row= [0, 1, 2], query= { SELECT count() AS A, count() AS B FROM scope()})": [
     {
       "A": 1,
       "B": 1
@@ -421,7 +413,7 @@
       "B": 3
     }
   ],
-  "036/000 Aggregate functions: Sum and Count together: SELECT * FROM foreach(row= [2, 3, 4], query= { SELECT count() AS A, sum(item=_value) AS B FROM scope()})": [
+  "035/000 Aggregate functions: Sum and Count together: SELECT * FROM foreach(row= [2, 3, 4], query= { SELECT count() AS A, sum(item=_value) AS B FROM scope()})": [
     {
       "A": 1,
       "B": 2
@@ -435,21 +427,21 @@
       "B": 9
     }
   ],
-  "037/000 Aggregate functions: Sum all rows: SELECT sum(item=_value) AS Total, sum(item=_value * 2) AS TotalDouble FROM foreach(row= [2, 3, 4]) GROUP BY 1": [
+  "036/000 Aggregate functions: Sum all rows: SELECT sum(item=_value) AS Total, sum(item=_value * 2) AS TotalDouble FROM foreach(row= [2, 3, 4]) GROUP BY 1": [
     {
       "Total": 9,
       "TotalDouble": 18
     }
   ],
-  "038/000 If function with stored query: LET Foo=SELECT 2 FROM scope() WHERE set_env(column=\"Eval\", value=TRUE)": null,
-  "038/001 If function with stored query: LET result\u003c=if(condition=TRUE, then=Foo)": null,
-  "038/002 If function with stored query: SELECT RootEnv.Eval AS Pass FROM scope()": [
+  "037/000 If function with stored query: LET Foo=SELECT 2 FROM scope() WHERE set_env(column=\"Eval\", value=TRUE)": null,
+  "037/001 If function with stored query: LET result\u003c=if(condition=TRUE, then=Foo)": null,
+  "037/002 If function with stored query: SELECT RootEnv.Eval AS Pass FROM scope()": [
     {
       "Pass": true
     }
   ],
-  "039/000 If function with subqueries: LET abc(a)=if(condition=a, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "039/001 If function with subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "038/000 If function with subqueries: LET abc(a)=if(condition=a, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "038/001 If function with subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
@@ -458,15 +450,15 @@
       ]
     }
   ],
-  "040/000 If function with functions: LET abc(a)=if(condition=a, then=set_env(column=\"EvalFunc\", value=TRUE))": null,
-  "040/001 If function with functions: LET _\u003c=SELECT abc(a=TRUE) FROM scope()": null,
-  "040/002 If function with functions: SELECT RootEnv.EvalFunc AS Pass FROM scope()": [
+  "039/000 If function with functions: LET abc(a)=if(condition=a, then=set_env(column=\"EvalFunc\", value=TRUE))": null,
+  "039/001 If function with functions: LET _\u003c=SELECT abc(a=TRUE) FROM scope()": null,
+  "039/002 If function with functions: SELECT RootEnv.EvalFunc AS Pass FROM scope()": [
     {
       "Pass": true
     }
   ],
-  "041/000 If function with conditions as subqueries: LET abc(a)=if(condition= { SELECT * FROM scope()}, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "041/001 If function with conditions as subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "040/000 If function with conditions as subqueries: LET abc(a)=if(condition= { SELECT * FROM scope()}, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "040/001 If function with conditions as subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
@@ -475,9 +467,9 @@
       ]
     }
   ],
-  "042/000 If function with conditions as stored query: LET stored_query=SELECT * FROM scope()": null,
-  "042/001 If function with conditions as stored query: LET abc(a)=if(condition=stored_query, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "042/002 If function with conditions as stored query: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "041/000 If function with conditions as stored query: LET stored_query=SELECT * FROM scope()": null,
+  "041/001 If function with conditions as stored query: LET abc(a)=if(condition=stored_query, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "041/002 If function with conditions as stored query: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
@@ -486,9 +478,9 @@
       ]
     }
   ],
-  "043/000 If function with conditions as vql functions: LET adder(a)=a =~ \"Foo\"": null,
-  "043/001 If function with conditions as vql functions: LET abc(a)=if(condition=adder(a=\"Foobar\"), then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "043/002 If function with conditions as vql functions: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "042/000 If function with conditions as vql functions: LET adder(a)=a =~ \"Foo\"": null,
+  "042/001 If function with conditions as vql functions: LET abc(a)=if(condition=adder(a=\"Foobar\"), then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "042/002 If function with conditions as vql functions: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
@@ -497,32 +489,32 @@
       ]
     }
   ],
-  "044/000 Multiline string constants: LET X='''This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\n''' + \"A string\"": null,
-  "044/001 Multiline string constants: SELECT X FROM scope()": [
+  "043/000 Multiline string constants: LET X='''This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\n''' + \"A string\"": null,
+  "043/001 Multiline string constants: SELECT X FROM scope()": [
     {
       "X": "This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\nA string"
     }
   ],
-  "045/000 Early breakout of foreach with infinite row query: SELECT * FROM foreach(row= { SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)}, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
+  "044/000 Early breakout of foreach with infinite row query: SELECT * FROM foreach(row= { SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)}, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
     {
       "Count": 1
     }
   ],
-  "046/000 Early breakout of foreach with stored query: LET X=SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
-  "046/001 Early breakout of foreach with stored query: SELECT * FROM foreach(row=X, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
+  "045/000 Early breakout of foreach with stored query: LET X=SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
+  "045/001 Early breakout of foreach with stored query: SELECT * FROM foreach(row=X, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
     {
       "Count": 1
     }
   ],
-  "047/000 Early breakout of foreach with stored query with parameters: LET X(Y)=SELECT Y, count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
-  "047/001 Early breakout of foreach with stored query with parameters: SELECT * FROM foreach(row=X(Y=23), query= { SELECT Y, Count FROM scope()}) LIMIT 1 ": [
+  "046/000 Early breakout of foreach with stored query with parameters: LET X(Y)=SELECT Y, count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
+  "046/001 Early breakout of foreach with stored query with parameters: SELECT * FROM foreach(row=X(Y=23), query= { SELECT Y, Count FROM scope()}) LIMIT 1 ": [
     {
       "Y": 23,
       "Count": 1
     }
   ],
-  "048/000 Expand stored query with parameters on associative: LET X(Y)=SELECT Y + 5 + value AS Foo FROM range(start=1, end=2)": null,
-  "048/001 Expand stored query with parameters on associative: SELECT X(Y=2).Foo FROM scope()": [
+  "047/000 Expand stored query with parameters on associative: LET X(Y)=SELECT Y + 5 + value AS Foo FROM range(start=1, end=2)": null,
+  "047/001 Expand stored query with parameters on associative: SELECT X(Y=2).Foo FROM scope()": [
     {
       "X(Y=2).Foo": [
         8,
@@ -530,7 +522,7 @@
       ]
     }
   ],
-  "049/000 Order by: SELECT * FROM foreach(row=(1, 8, 3, 2), query= { SELECT _value AS X FROM scope()}) ORDER BY X": [
+  "048/000 Order by: SELECT * FROM foreach(row=(1, 8, 3, 2), query= { SELECT _value AS X FROM scope()}) ORDER BY X": [
     {
       "X": 1
     },
@@ -544,7 +536,7 @@
       "X": 8
     }
   ],
-  "050/000 Group by also orders: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X FROM scope()}) GROUP BY X": [
+  "049/000 Group by also orders: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X FROM scope()}) GROUP BY X": [
     {
       "X": 1
     },
@@ -558,7 +550,7 @@
       "X": 2
     }
   ],
-  "051/000 Group by with explicit order by: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X, 10 - _value AS Y FROM scope()}) GROUP BY X ORDER BY Y": [
+  "050/000 Group by with explicit order by: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X, 10 - _value AS Y FROM scope()}) GROUP BY X ORDER BY Y": [
     {
       "X": 8,
       "Y": 2
@@ -576,8 +568,8 @@
       "Y": 9
     }
   ],
-  "052/000 Test array index: LET BIN\u003c=SELECT * FROM test()": null,
-  "052/001 Test array index: SELECT BIN, BIN[0] FROM scope()": [
+  "051/000 Test array index: LET BIN\u003c=SELECT * FROM test()": null,
+  "051/001 Test array index: SELECT BIN, BIN[0] FROM scope()": [
     {
       "BIN": [
         {
@@ -599,9 +591,9 @@
       }
     }
   ],
-  "053/000 Create Let expression: LET result=SELECT * FROM test()": null,
-  "053/001 Create Let expression: LET result\u003c=SELECT * FROM test()": null,
-  "053/002 Create Let expression: SELECT * FROM result": [
+  "052/000 Create Let expression: LET result=SELECT * FROM test()": null,
+  "052/001 Create Let expression: LET result\u003c=SELECT * FROM test()": null,
+  "052/002 Create Let expression: SELECT * FROM result": [
     {
       "foo": 0,
       "bar": 0
@@ -615,6 +607,13 @@
       "bar": 2
     }
   ],
-  "053/003 Create Let expression: SELECT * FROM no_such_result": null,
-  "053/004 Create Let expression: SELECT foobar FROM no_such_result": null
+  "052/003 Create Let expression: SELECT * FROM no_such_result": null,
+  "052/004 Create Let expression: SELECT foobar FROM no_such_result": null,
+  "053/000 Override function with a variable: LET format=5": null,
+  "053/001 Override function with a variable: SELECT format, format(format='%v', args=1) AS A FROM scope()": [
+    {
+      "format": 5,
+      "A": "1"
+    }
+  ]
 }

--- a/vfilter.go
+++ b/vfilter.go
@@ -1846,12 +1846,7 @@ func (self *_SymbolRef) ToString(scope types.Scope) string {
 	defer self.mu.Unlock()
 
 	symbol := self.Symbol
-	if self.Parameters == nil {
-		_, pres := scope.GetFunction(symbol)
-		if pres {
-			return symbol + "()"
-		}
-
+	if !self.Called && self.Parameters == nil {
 		return symbol
 	}
 

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -698,12 +698,6 @@ var multiVQLTest = []vqlTest{
 	{"Calling stored queries as plugins",
 		"LET X = SELECT Foo FROM scope() SELECT * FROM X(Foo=1)"},
 
-	// First two calls to Y are not function calls so they
-	// evaluate on the current scope. Third call makes a new scope
-	// which resets count().
-	{"Calling lazy expressions as functions creates a new scope",
-		"LET Y = count() SELECT Y AS Y1, Y AS Y2, Y() AS Y3 FROM scope()"},
-
 	{"Defining functions with args",
 		"LET X(Foo, Bar) = Foo + Bar SELECT X(Foo=5, Bar=2) FROM scope()"},
 
@@ -932,6 +926,9 @@ select * from result
 select * from no_such_result
 // Refer to non existent Let expression by column returns no rows
 select foobar from no_such_result`},
+
+	{"Override function with a variable",
+		"LET format = 5 SELECT format, format(format='%v', args=1) AS A FROM scope()"},
 }
 
 type _RangeArgs struct {


### PR DESCRIPTION
When overriding a built in function with a variable of the same name
there was confusion and VQL assumed the function was called - leading
to the result of the function as the value.