### PR TITLE
Add a warning when a large StoredQuery is materialized into memory.

### DIFF
--- a/arg_parser/args_test.go
+++ b/arg_parser/args_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Velocidex/ordereddict"
+	"github.com/alecthomas/assert"
 	"github.com/sebdah/goldie/v2"
 	"www.velocidex.com/golang/vfilter"
 	"www.velocidex.com/golang/vfilter/arg_parser"
@@ -230,6 +231,20 @@ func makeTestScope() types.Scope {
 	result := scope.NewScope().AppendFunctions(&argFunc{})
 	result.SetLogger(log.New(os.Stdout, "Log: ", log.Ldate|log.Ltime|log.Lshortfile))
 	return result
+}
+
+// Default values may be present in the arg struct and we should not
+// override them.
+func TestArgParsingDoesNotOverrideDefaults(t *testing.T) {
+	scope := makeTestScope()
+	arg := argFuncArgs{
+		Int: 5,
+	}
+	args := ordereddict.NewDict().Set("r", 1)
+	ctx := context.Background()
+	err := arg_parser.ExtractArgsWithContext(ctx, scope, args, &arg)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, arg.Int)
 }
 
 func TestArgParsing(t *testing.T) {

--- a/protocols/protocol_eq.go
+++ b/protocols/protocol_eq.go
@@ -2,6 +2,7 @@ package protocols
 
 import (
 	"reflect"
+	"time"
 
 	"www.velocidex.com/golang/vfilter/types"
 	"www.velocidex.com/golang/vfilter/utils"
@@ -46,6 +47,17 @@ func (self EqDispatcher) Eq(scope types.Scope, a types.Any, b types.Any) bool {
 			return t == rhs
 		}
 
+	case time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() == rhs.UnixNano()
+		}
+
+	case *time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() == rhs.UnixNano()
+		}
 	}
 
 	lhs, ok := utils.ToInt64(a)

--- a/protocols/protocol_gt.go
+++ b/protocols/protocol_gt.go
@@ -1,6 +1,8 @@
 package protocols
 
 import (
+	"time"
+
 	"www.velocidex.com/golang/vfilter/types"
 	"www.velocidex.com/golang/vfilter/utils"
 )
@@ -34,6 +36,17 @@ func (self GtDispatcher) Gt(scope types.Scope, a types.Any, b types.Any) bool {
 			return t > rhs
 		}
 
+	case time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() > rhs.UnixNano()
+		}
+
+	case *time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() > rhs.UnixNano()
+		}
 	}
 
 	lhs, ok := utils.ToInt64(a)

--- a/protocols/protocol_lt.go
+++ b/protocols/protocol_lt.go
@@ -1,6 +1,9 @@
 package protocols
 
 import (
+	"fmt"
+	"time"
+
 	"www.velocidex.com/golang/vfilter/types"
 	"www.velocidex.com/golang/vfilter/utils"
 )
@@ -37,6 +40,17 @@ func (self LtDispatcher) Lt(scope types.Scope, a types.Any, b types.Any) bool {
 			return t < rhs
 		}
 
+	case time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() < rhs.UnixNano()
+		}
+
+	case *time.Time:
+		rhs, ok := toTime(b)
+		if ok {
+			return t.UnixNano() < rhs.UnixNano()
+		}
 	}
 
 	lhs, ok := utils.ToInt64(a)
@@ -55,6 +69,18 @@ func (self LtDispatcher) Lt(scope types.Scope, a types.Any, b types.Any) bool {
 	}
 
 	return false
+}
+
+func toTime(a types.Any) (*time.Time, bool) {
+	switch t := a.(type) {
+	case time.Time:
+		return &t, true
+	case *time.Time:
+		return t, true
+	default:
+		fmt.Printf("type is %T\n", a)
+		return nil, false
+	}
 }
 
 func (self *LtDispatcher) AddImpl(elements ...LtProtocol) {

--- a/types/stored_query.go
+++ b/types/stored_query.go
@@ -13,6 +13,7 @@ type StoredQuery interface {
 // Materialize a stored query into a set of rows.
 func Materialize(ctx context.Context, scope Scope, stored_query StoredQuery) []Row {
 	result := []Row{}
+	var warned bool
 
 	// Materialize both queries to an array.
 	new_scope := scope.Copy()
@@ -20,6 +21,12 @@ func Materialize(ctx context.Context, scope Scope, stored_query StoredQuery) []R
 
 	for item := range stored_query.Eval(ctx, new_scope) {
 		result = append(result, item)
+
+		if !warned && len(result) > 10000 {
+			scope.Log("During Materialize of StoredQuery %s: Expand larger than 10,000 rows!",
+				ToString(stored_query, scope))
+			warned = true
+		}
 	}
 
 	return result


### PR DESCRIPTION
Sometime this can be caused by accident for exmple:

SELECT * FROM if(
  condition=FOO,
  then=if(
    condition=Bar,
    then=...
  ))

Will actually material the `then` clause because it accesses the
function version of if(). This is how to write this code:

SELECT * FROM if(
  condition=FOO,
  then={ SELECT * FROM if(
    condition=Bar,
    then=...
  )})