### PR TITLE
Update if function to relay stored queries.

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -461,108 +461,217 @@
       ]
     }
   ],
-  "037/000 Aggregate functions: Sum and Count together: SELECT * FROM foreach(row= [2, 3, 4], query= { SELECT count() AS A, sum(item=_value) AS B FROM scope()})": [
+  "037/000 Aggregate functions within a VQL function have their own state: LET Adder(X)=SELECT *, count() AS Count FROM range(start=10, end=10 + X, step=1)": null,
+  "037/001 Aggregate functions within a VQL function have their own state: SELECT * FROM foreach(row= { SELECT value FROM range(start=0, end=2, step=1)}, query= { SELECT * FROM Adder(X=value)})": [
     {
-      "A": 1,
-      "B": 2
+      "value": 10,
+      "Count": 1
     },
     {
-      "A": 1,
-      "B": 3
+      "value": 10,
+      "Count": 1
     },
     {
-      "A": 1,
-      "B": 4
+      "value": 11,
+      "Count": 2
+    },
+    {
+      "value": 10,
+      "Count": 1
+    },
+    {
+      "value": 11,
+      "Count": 2
+    },
+    {
+      "value": 12,
+      "Count": 3
     }
   ],
-  "038/000 Aggregate functions: Sum all rows: SELECT sum(item=_value) AS Total, sum(item=_value * 2) AS TotalDouble FROM foreach(row= [2, 3, 4]) GROUP BY 1": [
+  "038/000 Aggregate functions: Sum and Count together: LET MyValue\u003c=\"Hello\"": null,
+  "038/001 Aggregate functions: Sum and Count together: SELECT * FROM foreach(row= [2, 3, 4], query= { SELECT count() AS Count, sum(item=_value) AS Sum, MyValue FROM scope()})": [
+    {
+      "Count": 1,
+      "Sum": 2,
+      "MyValue": "Hello"
+    },
+    {
+      "Count": 2,
+      "Sum": 5,
+      "MyValue": "Hello"
+    },
+    {
+      "Count": 3,
+      "Sum": 9,
+      "MyValue": "Hello"
+    }
+  ],
+  "039/000 Aggregate functions: Sum and Count in stored query definition: LET MyValue\u003c=\"Hello\"": null,
+  "039/001 Aggregate functions: Sum and Count in stored query definition: LET CountMe(Value)=SELECT count() AS Count, Value, sum(item=Value) AS Sum, get(member=\"MyValue\") AS MyValueShouldBeNULL FROM scope()": null,
+  "039/002 Aggregate functions: Sum and Count in stored query definition: LET _value=10": null,
+  "039/003 Aggregate functions: Sum and Count in stored query definition: SELECT * FROM foreach(row= [2, 3, 4], query= { SELECT * FROM CountMe(Value=_value)})": [
+    {
+      "Count": 1,
+      "Value": 2,
+      "Sum": 2,
+      "MyValueShouldBeNULL": null
+    },
+    {
+      "Count": 1,
+      "Value": 3,
+      "Sum": 3,
+      "MyValueShouldBeNULL": null
+    },
+    {
+      "Count": 1,
+      "Value": 4,
+      "Sum": 4,
+      "MyValueShouldBeNULL": null
+    }
+  ],
+  "040/000 Aggregate functions: Sum and Count in stored query definition: LET MyValue\u003c=\"Hello\"": null,
+  "040/001 Aggregate functions: Sum and Count in stored query definition: LET CountMe(Value)=SELECT count() AS Count, Value, sum(item=Value) AS Sum, get(member=\"MyValue\") AS MyValueShouldBeNULL FROM scope()": null,
+  "040/002 Aggregate functions: Sum and Count in stored query definition: LET _value=10": null,
+  "040/003 Aggregate functions: Sum and Count in stored query definition: SELECT * FROM foreach(row= [2, 3, 4], query=CountMe(Value=_value))": [
+    {
+      "Count": 1,
+      "Value": 10,
+      "Sum": 10,
+      "MyValueShouldBeNULL": null
+    },
+    {
+      "Count": 2,
+      "Value": 10,
+      "Sum": 20,
+      "MyValueShouldBeNULL": null
+    },
+    {
+      "Count": 3,
+      "Value": 10,
+      "Sum": 30,
+      "MyValueShouldBeNULL": null
+    }
+  ],
+  "041/000 Aggregate functions: Sum all rows: SELECT sum(item=_value) AS Total, sum(item=_value * 2) AS TotalDouble FROM foreach(row= [2, 3, 4]) GROUP BY 1": [
     {
       "Total": 9,
       "TotalDouble": 18
     }
   ],
-  "039/000 If function with stored query: LET Foo=SELECT 2 FROM scope() WHERE set_env(column=\"Eval\", value=TRUE)": null,
-  "039/001 If function with stored query: LET result\u003c=if(condition=TRUE, then=Foo)": null,
-  "039/002 If function with stored query: SELECT RootEnv.Eval AS Pass FROM scope()": [
+  "042/000 If function with stored query: LET Foo=SELECT 2 FROM scope() WHERE set_env(column=\"Eval\", value=TRUE)": null,
+  "042/001 If function with stored query: LET result\u003c=if(condition=TRUE, then=Foo)": null,
+  "042/002 If function with stored query: SELECT RootEnv.Eval AS Pass FROM scope()": [
     {
       "Pass": true
     }
   ],
-  "040/000 If function with subqueries: LET abc(a)=if(condition=a, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "040/001 If function with subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "043/000 If function with subqueries: LET abc(a)=if(condition=a, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "043/001 If function with subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
-          "Pass": true
+          "Pass": null
         }
       ]
     }
   ],
-  "041/000 If function with functions: LET abc(a)=if(condition=a, then=set_env(column=\"EvalFunc\", value=TRUE))": null,
-  "041/001 If function with functions: LET _\u003c=SELECT abc(a=TRUE) FROM scope()": null,
-  "041/002 If function with functions: SELECT RootEnv.EvalFunc AS Pass FROM scope()": [
+  "044/000 If function with subqueries should return a lazy query: LET _\u003c=SELECT * FROM reset_objectwithmethods()": null,
+  "044/001 If function with subqueries should return a lazy query: LET MyCounter(Length)=SELECT * FROM foreach(row= { SELECT value FROM range(start=0, end=Length, step=1)}, query= { SELECT Value2 FROM objectwithmethods() WHERE Value2})": null,
+  "044/002 If function with subqueries should return a lazy query: SELECT * FROM if(condition=TRUE, then=if(condition=TRUE, then=MyCounter(Length=1000))) LIMIT 3 ": [
+    {
+      "Value2": "I am a method, called 1"
+    },
+    {
+      "Value2": "I am a method, called 2"
+    },
+    {
+      "Value2": "I am a method, called 3"
+    }
+  ],
+  "044/003 If function with subqueries should return a lazy query: SELECT * FROM if(condition=TRUE, then=if(condition=TRUE, then= { SELECT VarIsObjectWithMethods.Counter \u003c 20, Value2 =~ \"called\" FROM MyCounter(Length=100)})) LIMIT 3 ": [
+    {
+      "VarIsObjectWithMethods.Counter \u003c 20": true,
+      "Value2 =~ \"called\"": true
+    },
+    {
+      "VarIsObjectWithMethods.Counter \u003c 20": true,
+      "Value2 =~ \"called\"": true
+    },
+    {
+      "VarIsObjectWithMethods.Counter \u003c 20": true,
+      "Value2 =~ \"called\"": true
+    }
+  ],
+  "044/004 If function with subqueries should return a lazy query: SELECT Counter \u003c 20 FROM objectwithmethods() LIMIT 1 ": [
+    {
+      "Counter \u003c 20": true
+    }
+  ],
+  "045/000 If function with functions: LET abc(a)=if(condition=a, then=set_env(column=\"EvalFunc\", value=TRUE))": null,
+  "045/001 If function with functions: LET _\u003c=SELECT abc(a=TRUE) FROM scope()": null,
+  "045/002 If function with functions: SELECT RootEnv.EvalFunc AS Pass FROM scope()": [
     {
       "Pass": true
     }
   ],
-  "042/000 If function with conditions as subqueries: LET abc(a)=if(condition= { SELECT * FROM scope()}, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "042/001 If function with conditions as subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "046/000 If function with conditions as subqueries: LET abc(a)=if(condition= { SELECT * FROM scope()}, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "046/001 If function with conditions as subqueries: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
-          "Pass": true
+          "Pass": null
         }
       ]
     }
   ],
-  "043/000 If function with conditions as stored query: LET stored_query=SELECT * FROM scope()": null,
-  "043/001 If function with conditions as stored query: LET abc(a)=if(condition=stored_query, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "043/002 If function with conditions as stored query: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "047/000 If function with conditions as stored query: LET stored_query=SELECT * FROM scope()": null,
+  "047/001 If function with conditions as stored query: LET abc(a)=if(condition=stored_query, then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "047/002 If function with conditions as stored query: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
-          "Pass": true
+          "Pass": null
         }
       ]
     }
   ],
-  "044/000 If function with conditions as vql functions: LET adder(a)=a =~ \"Foo\"": null,
-  "044/001 If function with conditions as vql functions: LET abc(a)=if(condition=adder(a=\"Foobar\"), then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
-  "044/002 If function with conditions as vql functions: SELECT abc(a=TRUE) AS Pass FROM scope()": [
+  "048/000 If function with conditions as vql functions: LET adder(a)=a =~ \"Foo\"": null,
+  "048/001 If function with conditions as vql functions: LET abc(a)=if(condition=adder(a=\"Foobar\"), then= { SELECT a AS Pass FROM scope()}, else= { SELECT false AS Pass FROM scope()})": null,
+  "048/002 If function with conditions as vql functions: SELECT abc(a=TRUE) AS Pass FROM scope()": [
     {
       "Pass": [
         {
-          "Pass": true
+          "Pass": null
         }
       ]
     }
   ],
-  "045/000 Multiline string constants: LET X='''This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\n''' + \"A string\"": null,
-  "045/001 Multiline string constants: SELECT X FROM scope()": [
+  "049/000 Multiline string constants: LET X='''This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\n''' + \"A string\"": null,
+  "049/001 Multiline string constants: SELECT X FROM scope()": [
     {
       "X": "This\nis\na\nmultiline with 'quotes' and \"double quotes\" and \\ backslashes\nA string"
     }
   ],
-  "046/000 Early breakout of foreach with infinite row query: SELECT * FROM foreach(row= { SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)}, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
+  "050/000 Early breakout of foreach with infinite row query: SELECT * FROM foreach(row= { SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)}, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
     {
       "Count": 1
     }
   ],
-  "047/000 Early breakout of foreach with stored query: LET X=SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
-  "047/001 Early breakout of foreach with stored query: SELECT * FROM foreach(row=X, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
+  "051/000 Early breakout of foreach with stored query: LET X=SELECT count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=6)": null,
+  "051/001 Early breakout of foreach with stored query: SELECT * FROM foreach(row=X, query= { SELECT Count FROM scope()}) LIMIT 1 ": [
     {
       "Count": 1
     }
   ],
-  "048/000 Early breakout of foreach with stored query with parameters: LET X(Y)=SELECT Y, count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=5)": null,
-  "048/001 Early breakout of foreach with stored query with parameters: SELECT * FROM foreach(row=X(Y=23), query= { SELECT Y, Count FROM scope()}) LIMIT 1 ": [
+  "052/000 Early breakout of foreach with stored query with parameters: LET X(Y)=SELECT Y, count() AS Count FROM range(start=1, end=20) WHERE panic(column=Count, value=7)": null,
+  "052/001 Early breakout of foreach with stored query with parameters: SELECT * FROM foreach(row=X(Y=23), query= { SELECT Y, Count FROM scope()}) LIMIT 1 ": [
     {
       "Y": 23,
       "Count": 1
     }
   ],
-  "049/000 Expand stored query with parameters on associative: LET X(Y)=SELECT Y + 5 + value AS Foo FROM range(start=1, end=2)": null,
-  "049/001 Expand stored query with parameters on associative: SELECT X(Y=2).Foo FROM scope()": [
+  "053/000 Expand stored query with parameters on associative: LET X(Y)=SELECT Y + 5 + value AS Foo FROM range(start=1, end=2)": null,
+  "053/001 Expand stored query with parameters on associative: SELECT X(Y=2).Foo FROM scope()": [
     {
       "X(Y=2).Foo": [
         8,
@@ -570,7 +679,7 @@
       ]
     }
   ],
-  "050/000 Order by: SELECT * FROM foreach(row=(1, 8, 3, 2), query= { SELECT _value AS X FROM scope()}) ORDER BY X": [
+  "054/000 Order by: SELECT * FROM foreach(row=(1, 8, 3, 2), query= { SELECT _value AS X FROM scope()}) ORDER BY X": [
     {
       "X": 1
     },
@@ -584,7 +693,7 @@
       "X": 8
     }
   ],
-  "051/000 Group by also orders: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X FROM scope()}) GROUP BY X": [
+  "055/000 Group by also orders: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X FROM scope()}) GROUP BY X": [
     {
       "X": 1
     },
@@ -598,7 +707,7 @@
       "X": 2
     }
   ],
-  "052/000 Group by with explicit order by: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X, 10 - _value AS Y FROM scope()}) GROUP BY X ORDER BY Y": [
+  "056/000 Group by with explicit order by: SELECT * FROM foreach(row=(1, 1, 1, 1, 8, 3, 3, 3, 2), query= { SELECT _value AS X, 10 - _value AS Y FROM scope()}) GROUP BY X ORDER BY Y": [
     {
       "X": 8,
       "Y": 2
@@ -616,8 +725,8 @@
       "Y": 9
     }
   ],
-  "053/000 Test array index: LET BIN\u003c=SELECT * FROM test()": null,
-  "053/001 Test array index: SELECT BIN, BIN[0] FROM scope()": [
+  "057/000 Test array index: LET BIN\u003c=SELECT * FROM test()": null,
+  "057/001 Test array index: SELECT BIN, BIN[0] FROM scope()": [
     {
       "BIN": [
         {
@@ -639,9 +748,9 @@
       }
     }
   ],
-  "054/000 Test array index with expression: LET Index(X)=X - 1": null,
-  "054/001 Test array index with expression: LET BIN\u003c=SELECT * FROM test()": null,
-  "054/002 Test array index with expression: SELECT BIN, BIN[Index(X=2)] FROM scope()": [
+  "058/000 Test array index with expression: LET Index(X)=X - 1": null,
+  "058/001 Test array index with expression: LET BIN\u003c=SELECT * FROM test()": null,
+  "058/002 Test array index with expression: SELECT BIN, BIN[Index(X=2)] FROM scope()": [
     {
       "BIN": [
         {
@@ -663,7 +772,7 @@
       }
     }
   ],
-  "054/003 Test array index with expression: SELECT BIN, BIN[Index(X=0)] FROM scope()": [
+  "058/003 Test array index with expression: SELECT BIN, BIN[Index(X=0)] FROM scope()": [
     {
       "BIN": [
         {
@@ -685,9 +794,9 @@
       }
     }
   ],
-  "055/000 Create Let expression: LET result=SELECT * FROM test()": null,
-  "055/001 Create Let expression: LET result\u003c=SELECT * FROM test()": null,
-  "055/002 Create Let expression: SELECT * FROM result": [
+  "059/000 Create Let expression: LET result=SELECT * FROM test()": null,
+  "059/001 Create Let expression: LET result\u003c=SELECT * FROM test()": null,
+  "059/002 Create Let expression: SELECT * FROM result": [
     {
       "foo": 0,
       "bar": 0
@@ -701,17 +810,17 @@
       "bar": 2
     }
   ],
-  "055/003 Create Let expression: SELECT * FROM no_such_result": null,
-  "055/004 Create Let expression: SELECT foobar FROM no_such_result": null,
-  "056/000 Override function with a variable: LET format=5": null,
-  "056/001 Override function with a variable: SELECT format, format(format='%v', args=1) AS A FROM scope()": [
+  "059/003 Create Let expression: SELECT * FROM no_such_result": null,
+  "059/004 Create Let expression: SELECT foobar FROM no_such_result": null,
+  "060/000 Override function with a variable: LET format=5": null,
+  "060/001 Override function with a variable: SELECT format, format(format='%v', args=1) AS A FROM scope()": [
     {
       "format": 5,
       "A": "1"
     }
   ],
-  "057/000 Stored Expressions as plugins: LET Foo=(dict(X=1), dict(X=2), dict(X=3))": null,
-  "057/001 Stored Expressions as plugins: SELECT * FROM Foo": [
+  "061/000 Stored Expressions as plugins: LET Foo=(dict(X=1), dict(X=2), dict(X=3))": null,
+  "061/001 Stored Expressions as plugins: SELECT * FROM Foo": [
     {
       "X": 1
     },
@@ -722,8 +831,8 @@
       "X": 3
     }
   ],
-  "058/000 Materialized Expressions as plugins: LET Foo\u003c=(dict(X=1), dict(X=2), dict(X=3))": null,
-  "058/001 Materialized Expressions as plugins: SELECT * FROM Foo": [
+  "062/000 Materialized Expressions as plugins: LET Foo\u003c=(dict(X=1), dict(X=2), dict(X=3))": null,
+  "062/001 Materialized Expressions as plugins: SELECT * FROM Foo": [
     {
       "X": 1
     },
@@ -734,8 +843,8 @@
       "X": 3
     }
   ],
-  "059/000 Stored Expressions as plugins with args: LET Foo(X)=(dict(X=1 + X), dict(X=2 + X), dict(X=3 + X))": null,
-  "059/001 Stored Expressions as plugins with args: SELECT * FROM Foo(X=1)": [
+  "063/000 Stored Expressions as plugins with args: LET Foo(X)=(dict(X=1 + X), dict(X=2 + X), dict(X=3 + X))": null,
+  "063/001 Stored Expressions as plugins with args: SELECT * FROM Foo(X=1)": [
     {
       "X": 2
     },
@@ -746,8 +855,8 @@
       "X": 4
     }
   ],
-  "060/000 Slice Range: LET X\u003c=(0, 1, 2, 3, 4, 5, 6, 7)": null,
-  "060/001 Slice Range: SELECT X[2 : ], X[2 : 4], X[ : 2], X[-1], X[-2], X[-2 : ], X[2 : -1] FROM scope()": [
+  "064/000 Slice Range: LET X\u003c=(0, 1, 2, 3, 4, 5, 6, 7)": null,
+  "064/001 Slice Range: SELECT X[2 : ], X[2 : 4], X[ : 2], X[-1], X[-2], X[-2 : ], X[2 : -1] FROM scope()": [
     {
       "X[2 : ]": [
         2,
@@ -780,18 +889,20 @@
       ]
     }
   ],
-  "061/000 Access object methods as properties.: LET _\u003c=SELECT * FROM reset_objectwithmethods()": null,
-  "061/001 Access object methods as properties.: SELECT * FROM objectwithmethods()": [
+  "065/000 Access object methods as properties.: LET _\u003c=SELECT * FROM reset_objectwithmethods()": null,
+  "065/001 Access object methods as properties.: SELECT * FROM objectwithmethods()": [
     {
       "Value1": 1,
-      "Value2": "I am a method, called 1"
+      "Value2": "I am a method, called 1",
+      "Counter": 1
     },
     {
       "Value1": 2,
-      "Value2": "I am a method, called 2"
+      "Value2": "I am a method, called 2",
+      "Counter": 2
     }
   ],
-  "061/002 Access object methods as properties.: SELECT Value1, Value2 + \"X\" FROM objectwithmethods()": [
+  "065/002 Access object methods as properties.: SELECT Value1, Value2 + \"X\" FROM objectwithmethods()": [
     {
       "Value1": 1,
       "Value2 + \"X\"": "I am a method, called 3X"
@@ -801,7 +912,7 @@
       "Value2 + \"X\"": "I am a method, called 4X"
     }
   ],
-  "061/003 Access object methods as properties.: SELECT Value1 FROM objectwithmethods()": [
+  "065/003 Access object methods as properties.: SELECT Value1 FROM objectwithmethods()": [
     {
       "Value1": 1
     },
@@ -809,8 +920,8 @@
       "Value1": 2
     }
   ],
-  "061/004 Access object methods as properties.: SELECT Value2 + \"X\" FROM objectwithmethods() WHERE False": null,
-  "061/005 Access object methods as properties.: SELECT if(condition=1, then=2, else=Value2) FROM objectwithmethods()": [
+  "065/004 Access object methods as properties.: SELECT Value2 + \"X\" FROM objectwithmethods() WHERE False": null,
+  "065/005 Access object methods as properties.: SELECT if(condition=1, then=2, else=Value2) FROM objectwithmethods()": [
     {
       "if(condition=1, then=2, else=Value2)": 2
     },
@@ -818,7 +929,7 @@
       "if(condition=1, then=2, else=Value2)": 2
     }
   ],
-  "061/006 Access object methods as properties.: SELECT Value2 FROM objectwithmethods() WHERE Value2 =~ \"method\"": [
+  "065/006 Access object methods as properties.: SELECT Value2 FROM objectwithmethods() WHERE Value2 =~ \"method\"": [
     {
       "Value2": "I am a method, called 5"
     },
@@ -826,33 +937,33 @@
       "Value2": "I am a method, called 6"
     }
   ],
-  "062/000 Access object methods as properties: LET _\u003c=SELECT * FROM reset_objectwithmethods()": null,
-  "062/001 Access object methods as properties: SELECT VarIsObjectWithMethods.Value1 FROM scope()": [
+  "066/000 Access object methods as properties: LET _\u003c=SELECT * FROM reset_objectwithmethods()": null,
+  "066/001 Access object methods as properties: SELECT VarIsObjectWithMethods.Value1 FROM scope()": [
     {
       "VarIsObjectWithMethods.Value1": 1
     }
   ],
-  "062/002 Access object methods as properties: SELECT VarIsObjectWithMethods.Value2 FROM scope()": [
+  "066/002 Access object methods as properties: SELECT VarIsObjectWithMethods.Value2 FROM scope()": [
     {
       "VarIsObjectWithMethods.Value2": "I am a method, called 1"
     }
   ],
-  "062/003 Access object methods as properties: SELECT VarIsObjectWithMethods.Value1 FROM scope()": [
+  "066/003 Access object methods as properties: SELECT VarIsObjectWithMethods.Value1 FROM scope()": [
     {
       "VarIsObjectWithMethods.Value1": 1
     }
   ],
-  "062/004 Access object methods as properties: SELECT if(condition=1, then=2, else=VarIsObjectWithMethods.Value2) FROM scope()": [
+  "066/004 Access object methods as properties: SELECT if(condition=1, then=2, else=VarIsObjectWithMethods.Value2) FROM scope()": [
     {
       "if(condition=1, then=2, else=VarIsObjectWithMethods.Value2)": 2
     }
   ],
-  "062/005 Access object methods as properties: SELECT VarIsObjectWithMethods.Value2 FROM scope()": [
+  "066/005 Access object methods as properties: SELECT VarIsObjectWithMethods.Value2 FROM scope()": [
     {
       "VarIsObjectWithMethods.Value2": "I am a method, called 2"
     }
   ],
-  "062/006 Access object methods as properties: SELECT if(condition=FALSE, then=2, else=VarIsObjectWithMethods.Value2) + \"X\", VarIsObjectWithMethods.Value2 =~ \"I am a method\", VarIsObjectWithMethods.Value2 FROM scope()": [
+  "066/006 Access object methods as properties: SELECT if(condition=FALSE, then=2, else=VarIsObjectWithMethods.Value2) + \"X\", VarIsObjectWithMethods.Value2 =~ \"I am a method\", VarIsObjectWithMethods.Value2 FROM scope()": [
     {
       "if(condition=FALSE, then=2, else=VarIsObjectWithMethods.Value2) + \"X\"": "I am a method, called 3X",
       "VarIsObjectWithMethods.Value2 =~ \"I am a method\"": true,

--- a/fixtures/vql_queries.golden
+++ b/fixtures/vql_queries.golden
@@ -590,9 +590,9 @@
       ]
     }
   ],
-  "063 If function should be lazy: SELECT if(condition=FALSE, then=panic(column=2, value=2)) FROM scope()": [
+  "063 If function should be lazy: SELECT if(condition=FALSE, then=panic(column=3, value=3)) FROM scope()": [
     {
-      "if(condition=FALSE, then=panic(column=2, value=2))": null
+      "if(condition=FALSE, then=panic(column=3, value=3))": null
     }
   ],
   "064 If function should be lazy: SELECT if(condition=TRUE, else=panic(column=7, value=7)) FROM scope()": [

--- a/plugins/foreach.go
+++ b/plugins/foreach.go
@@ -83,9 +83,9 @@ func (self _ForeachPluginImpl) Call(ctx context.Context,
 					continue
 				}
 
-				// Evaluate the query on a new sub
-				// scope. The query can refer to rows
-				// returned by the "row" query.
+				// Evaluate the query on a new sub scope. The query
+				// can refer to rows returned by the "row" query -
+				// therefore it is **not** isolated.
 				child_scope := scope.Copy()
 				// child_scope is closed in the pool worker.
 

--- a/scope/fixtures/TestDestructors.golden
+++ b/scope/fixtures/TestDestructors.golden
@@ -19,8 +19,8 @@
     "Plugin Open rows_query 1",
     "Func Open iterator_func 1",
     "Func Close iterator_func 1",
-    "Func Open iterator_func 1",
-    "Func Close iterator_func 1",
+    "Func Open iterator_func 2",
+    "Func Close iterator_func 2",
     "Plugin Close rows_query 1"
   ],
   "004 Lazy function: SELECT destructor(name='lazy_func') AS X FROM scope() WHERE FALSE - markers": [],

--- a/types/types.go
+++ b/types/types.go
@@ -5,6 +5,13 @@ package types
 // A Generic object which may be returned in a row from a plugin.
 type Any interface{}
 
+// A Special type which can be used as a plugin parameter. This is
+// used to prevent any kind of reducing or wrapping of the arg and
+// leaves the caller to handle all aspects. This is mostly used in
+// if() where it is critical to not evaluate unused branches in any
+// circumstance.
+type LazyAny interface{}
+
 // Plugins may return anything as long as there is a valid
 // Associative() protocol handler. VFilter will simply call
 // scope.Associative(row, column) to retrieve the cell value for each


### PR DESCRIPTION
This does the right thing now:

SELECT * FROM if(condition=....,
then=if(condition=..., then={
  SELECT * FROM ...
}))

Previously that expression would materialize the inner query and lead
to high memory usage.