### PR TITLE
Expand stored queries in a column cell.

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -996,5 +996,25 @@
         3
       ]
     }
+  ],
+  "070/000 If function with stored query: LET FooBar=SELECT \"A\" FROM scope()": null,
+  "070/001 If function with stored query: LET B=SELECT if(condition=TRUE, then=FooBar) AS Item FROM scope()": null,
+  "070/002 If function with stored query: SELECT B, FooBar FROM scope()": [
+    {
+      "B": [
+        {
+          "Item": [
+            {
+              "\"A\"": "A"
+            }
+          ]
+        }
+      ],
+      "FooBar": [
+        {
+          "\"A\"": "A"
+        }
+      ]
+    }
   ]
 }

--- a/functions/if.go
+++ b/functions/if.go
@@ -49,6 +49,7 @@ func (self _IfFunction) Call(
 
 		switch t := arg.Then.(type) {
 		case types.StoredQuery:
+			// If Function with subqueries should return a lazy subquery
 			return t
 
 		case types.LazyExpr:
@@ -73,6 +74,7 @@ func (self _IfFunction) Call(
 
 	switch t := arg.Else.(type) {
 	case types.StoredQuery:
+		// If Function with subqueries should return a lazy subquery
 		return t
 
 	case types.LazyExpr:

--- a/vfilter.go
+++ b/vfilter.go
@@ -983,7 +983,16 @@ func (self *_SelectExpression) Transform(
 			// any scope but needs to resolve members in
 			// the scope it was created from.
 			func(ctx context.Context, scope types.Scope) Any {
-				return expr.Reduce(ctx, new_scope)
+				item := expr.Reduce(ctx, new_scope)
+				switch t := item.(type) {
+
+				// if we end up with a stored query in a column value
+				// we expand it since all columns should be
+				// materialized.
+				case types.StoredQuery:
+					return types.Materialize(ctx, new_scope, t)
+				}
+				return item
 			})
 	}
 

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -1166,6 +1166,13 @@ SELECT * FROM MyFunc(X=1)`},
 	{"Function returning array", `
 SELECT func_foo(return=ArrayValue) FROM scope()
 `},
+
+	{"If function with stored query", `
+LET FooBar = SELECT "A" FROM scope()
+LET B = SELECT if(condition=TRUE, then=FooBar) AS Item
+FROM scope()
+SELECT B, FooBar FROM scope()
+`},
 }
 
 type _RangeArgs struct {


### PR DESCRIPTION
The if() function deliberately keeps its stored query input
unmaterialized in order to propagate lazily to callers. However
sometimes this stored query ends up in the column cell and there it
should be materialized.