### PR TITLE
Allow custom materializers to be set in the scope.

### DIFF
--- a/lazy.go
+++ b/lazy.go
@@ -138,6 +138,10 @@ func (self *LazyExprImpl) ReduceWithScope(
 	}
 
 	switch t := result.(type) {
+
+	case types.Materializer:
+		return t.Materialize(ctx, scope)
+
 	// StoredQuery objects are first class objects that can be
 	// passed around into function args.
 	case StoredQuery:

--- a/marshal/fixtures/Serialization.golden
+++ b/marshal/fixtures/Serialization.golden
@@ -25,7 +25,7 @@
       "vars": {
         "X": {
           "type": "JSON",
-          "comment": "Default encoding from []types.Row",
+          "comment": "Default encoding from *materializer.InMemoryMatrializer",
           "data": [
             {
               "_value": 0,

--- a/materializer/in_memory.go
+++ b/materializer/in_memory.go
@@ -1,0 +1,87 @@
+package materializer
+
+import (
+	"context"
+	"encoding/json"
+
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+// An in memory materializer - this is equivalent to the old behavior
+// of expanding all rows in memory.
+type InMemoryMatrializer struct {
+	rows []types.Row
+}
+
+func NewInMemoryMatrializer(rows []types.Row) *InMemoryMatrializer {
+	return &InMemoryMatrializer{rows}
+}
+
+// Support StoredQuery protocol.
+func (self InMemoryMatrializer) Eval(
+	ctx context.Context, scope types.Scope) <-chan types.Row {
+
+	output_chan := make(chan types.Row)
+	go func() {
+		defer close(output_chan)
+
+		for _, row := range self.rows {
+			select {
+			case <-ctx.Done():
+				return
+			case output_chan <- row:
+			}
+		}
+	}()
+
+	return output_chan
+}
+
+// Support indexing (Associative protocol)
+func (self InMemoryMatrializer) Applicable(a types.Any, b types.Any) bool {
+	_, ok := a.(*InMemoryMatrializer)
+	if !ok {
+		return false
+	}
+
+	return true
+}
+
+// Just deletegate to our contained rows array.
+func (self InMemoryMatrializer) GetMembers(scope types.Scope, a types.Any) []string {
+	a_materializer, ok := a.(*InMemoryMatrializer)
+	if !ok {
+		return nil
+	}
+
+	return scope.GetMembers(a_materializer.rows)
+}
+
+func (self InMemoryMatrializer) Associative(scope types.Scope, a types.Any, b types.Any) (res types.Any, pres bool) {
+	a_materializer, ok := a.(*InMemoryMatrializer)
+	if !ok {
+		return nil, false
+	}
+
+	return scope.Associative(a_materializer.rows, b)
+}
+
+// Support JSON Marshal protocol
+func (self *InMemoryMatrializer) MarshalJSON() ([]byte, error) {
+	return json.Marshal(self.rows)
+}
+
+// An object implementing the ScopeMaterializer interface. This is the
+// default meterializer used in VQL to expand a LET query into the
+// scope. It returns wrapper that contains the list of rows in
+// memory. Library users may register a more sophisticated
+// meterializer that backs data in more scalable storage to avoid
+// memory costs.
+type DefaultMaterializer struct{}
+
+func (self DefaultMaterializer) Materialize(
+	ctx context.Context, scope types.Scope,
+	operator string, query types.StoredQuery) types.StoredQuery {
+	rows := types.Materialize(ctx, scope, query)
+	return &InMemoryMatrializer{rows}
+}

--- a/protocols/builtin.go
+++ b/protocols/builtin.go
@@ -1,6 +1,8 @@
 package protocols
 
-import "www.velocidex.com/golang/vfilter/types"
+import (
+	"www.velocidex.com/golang/vfilter/types"
+)
 
 func GetBuiltinTypes() []types.Any {
 	return []types.Any{

--- a/protocols/protocol_add.go
+++ b/protocols/protocol_add.go
@@ -73,7 +73,7 @@ func (self AddDispatcher) Add(scope types.Scope, a types.Any, b types.Any) types
 
 func (self *AddDispatcher) AddImpl(elements ...AddProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]AddProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_associative.go
+++ b/protocols/protocol_associative.go
@@ -128,9 +128,12 @@ func (self *AssociativeDispatcher) GetMembers(
 	return DefaultAssociative{}.GetMembers(scope, a)
 }
 
+// When adding external protocols they need to be considered before
+// any built in protocols so they are able to override the built
+// ins. Therefore add them to the front of the protocols array.
 func (self *AssociativeDispatcher) AddImpl(elements ...AssociativeProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]AssociativeProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_bool.go
+++ b/protocols/protocol_bool.go
@@ -77,7 +77,7 @@ func (self BoolDispatcher) Bool(ctx context.Context, scope types.Scope, a types.
 
 func (self *BoolDispatcher) AddImpl(elements ...BoolProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]BoolProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_div.go
+++ b/protocols/protocol_div.go
@@ -78,6 +78,6 @@ func (self DivDispatcher) Div(scope types.Scope, a types.Any, b types.Any) types
 
 func (self *DivDispatcher) AddImpl(elements ...DivProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]DivProtocol{impl}, self.impl...)
 	}
 }

--- a/protocols/protocol_eq.go
+++ b/protocols/protocol_eq.go
@@ -88,7 +88,7 @@ func (self EqDispatcher) Eq(scope types.Scope, a types.Any, b types.Any) bool {
 
 func (self *EqDispatcher) AddImpl(elements ...EqProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]EqProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_gt.go
+++ b/protocols/protocol_gt.go
@@ -72,6 +72,6 @@ func (self GtDispatcher) Gt(scope types.Scope, a types.Any, b types.Any) bool {
 
 func (self *GtDispatcher) AddImpl(elements ...GtProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]GtProtocol{impl}, self.impl...)
 	}
 }

--- a/protocols/protocol_iterate.go
+++ b/protocols/protocol_iterate.go
@@ -79,7 +79,7 @@ func (self IterateDispatcher) Iterate(
 
 func (self *IterateDispatcher) AddImpl(elements ...IterateProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]IterateProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_lt.go
+++ b/protocols/protocol_lt.go
@@ -86,6 +86,6 @@ func toTime(a types.Any) (*time.Time, bool) {
 
 func (self *LtDispatcher) AddImpl(elements ...LtProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]LtProtocol{impl}, self.impl...)
 	}
 }

--- a/protocols/protocol_membership.go
+++ b/protocols/protocol_membership.go
@@ -71,6 +71,6 @@ func (self MembershipDispatcher) Membership(scope types.Scope, a types.Any, b ty
 
 func (self *MembershipDispatcher) AddImpl(elements ...MembershipProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]MembershipProtocol{impl}, self.impl...)
 	}
 }

--- a/protocols/protocol_mul.go
+++ b/protocols/protocol_mul.go
@@ -76,6 +76,6 @@ func (self MulDispatcher) Mul(scope types.Scope, a types.Any, b types.Any) types
 
 func (self *MulDispatcher) AddImpl(elements ...MulProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]MulProtocol{impl}, self.impl...)
 	}
 }

--- a/protocols/protocol_regex.go
+++ b/protocols/protocol_regex.go
@@ -62,7 +62,7 @@ func (self RegexDispatcher) Match(scope types.Scope, pattern types.Any, target t
 
 func (self *RegexDispatcher) AddImpl(elements ...RegexProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]RegexProtocol{impl}, self.impl...)
 	}
 }
 

--- a/protocols/protocol_sub.go
+++ b/protocols/protocol_sub.go
@@ -68,6 +68,6 @@ func (self SubDispatcher) Sub(scope types.Scope, a types.Any, b types.Any) types
 
 func (self *SubDispatcher) AddImpl(elements ...SubProtocol) {
 	for _, impl := range elements {
-		self.impl = append(self.impl, impl)
+		self.impl = append([]SubProtocol{impl}, self.impl...)
 	}
 }

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/vfilter/functions"
+	"www.velocidex.com/golang/vfilter/materializer"
 	"www.velocidex.com/golang/vfilter/plugins"
 	"www.velocidex.com/golang/vfilter/protocols"
 	"www.velocidex.com/golang/vfilter/types"
@@ -289,6 +290,11 @@ func (self *Scope) Iterate(ctx context.Context, a types.Any) <-chan types.Row {
 	return self.dispatcher.iterator.Iterate(ctx, self, a)
 }
 
+func (self *Scope) Materialize(ctx context.Context,
+	name string, query types.StoredQuery) types.StoredQuery {
+	return self.dispatcher.Materializer.Materialize(ctx, self, name, query)
+}
+
 func (self *Scope) StackDepth() int {
 	self.Lock()
 	defer self.Unlock()
@@ -506,6 +512,8 @@ func NewScope() *Scope {
 		ordereddict.NewDict().
 			Set("NULL", types.Null{}))
 
+	dispatcher.AddProtocolImpl(materializer.InMemoryMatrializer{})
+
 	return result
 }
 
@@ -519,6 +527,10 @@ func (self *Scope) SetSorter(sorter types.Sorter) {
 
 func (self *Scope) SetGrouper(grouper types.Grouper) {
 	self.dispatcher.SetGrouper(grouper)
+}
+
+func (self *Scope) SetMaterializer(materializer types.ScopeMaterializer) {
+	self.dispatcher.SetMaterializer(materializer)
 }
 
 // Fetch the field from the scope variables.

--- a/stored.go
+++ b/stored.go
@@ -90,6 +90,9 @@ func (self *_StoredQuery) Call(ctx context.Context,
 		case types.LazyExpr:
 			v = t.Reduce(ctx)
 
+		case types.Materializer:
+			v = t.Materialize(ctx, sub_scope)
+
 		case types.StoredQuery:
 			v = types.Materialize(ctx, sub_scope, t)
 		}

--- a/types/scope.go
+++ b/types/scope.go
@@ -8,6 +8,15 @@ import (
 	"github.com/Velocidex/ordereddict"
 )
 
+// A ScopeMaterializer handles VQL Let Materialize operators (<=). The
+// returned object will be added to the scope and can be accessed in
+// subsequent queries. This allows users of vfilter the ability to
+// customize the implementation of materialized queries.
+type ScopeMaterializer interface {
+	Materialize(ctx context.Context, scope Scope,
+		name string, query StoredQuery) StoredQuery
+}
+
 // A scope is passed inside the evaluation context.  Although this is
 // an interface, there is currently only a single implementation
 // (scope.Scope). The interface exposes the public methods.
@@ -43,6 +52,8 @@ type Scope interface {
 	Membership(a Any, b Any) bool
 	Associative(a Any, b Any) (Any, bool)
 	GetMembers(a Any) []string
+	Materialize(ctx context.Context,
+		name string, query StoredQuery) StoredQuery
 
 	Match(a Any, b Any) bool
 	Iterate(ctx context.Context, a Any) <-chan Row
@@ -55,6 +66,7 @@ type Scope interface {
 	// Program a custom sorter
 	SetSorter(sorter Sorter)
 	SetGrouper(grouper Grouper)
+	SetMaterializer(materializer ScopeMaterializer)
 
 	// We can program the scope's protocols
 	AddProtocolImpl(implementations ...Any) Scope

--- a/types/string.go
+++ b/types/string.go
@@ -20,6 +20,9 @@ func ToString(ctx context.Context,
 	case LazyExpr:
 		return ToString(ctx, scope, t.Reduce(ctx))
 
+	case Materializer:
+		return ToString(ctx, scope, t.Materialize(ctx, scope))
+
 		// Materialize stored queries into an array.
 	case StoredQuery:
 		return ToString(ctx, scope, Materialize(ctx, scope, t))
@@ -28,9 +31,6 @@ func ToString(ctx context.Context,
 		// call it lazily if it is here.
 	case func() Any:
 		return ToString(ctx, scope, t())
-
-	case Materializer:
-		return ToString(ctx, scope, t.Materialize(ctx, scope))
 
 	case StringProtocol:
 		return t.ToString(scope)

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -1374,7 +1374,7 @@ func TestMultiVQLQueries(t *testing.T) {
 	// Store the result in ordered dict so we have a consistent golden file.
 	result := ordereddict.NewDict()
 	for i, testCase := range multiVQLTest {
-		if false && i != 44 && i != 390 {
+		if false && i != 58 {
 			continue
 		}
 		scope := makeTestScope()


### PR DESCRIPTION
VQL LET X <= SELECT queries materialize all rows into memory. This can create a lot of problems and requires care from VQL authors.

This PR allows the materialization to be customized by installing a custom materializer in the scope. Velociraptor uses a temp file based custom materializer which controls memory use for ineffiient queries.