### PR TITLE
Bugfix: Slices with end index larger than the length

### DIFF
--- a/protocols/utils.go
+++ b/protocols/utils.go
@@ -21,8 +21,13 @@ func getRanges(field_name []*int64, array_length int64) (
 	if end_range < 0 {
 		end_range = array_length + end_range
 	}
+
 	if end_range < 0 {
 		end_range = 0
+	}
+
+	if end_range > array_length {
+		end_range = array_length
 	}
 
 	return start_range, end_range

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -240,6 +240,10 @@ var execTestsSerialization = []execTest{
 	{"'Hello'[1]", 101},
 	{"'Hello'[-1]", 111},
 	{"'Hello'[:3]", "Hel"},
+
+	// Indexing past the end of the array should clamp to end.
+	{"'Hello'[2:300]", "llo"},
+	{"'Hello'[-2:300]", "lo"},
 	{"'Hello'[-3:]", "llo"},
 
 	// Rgexp operator


### PR DESCRIPTION
Should clap the end to the entire range.