### PR TITLE
Refactor the flatten plugin

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -1074,5 +1074,90 @@
     {
       "\"A\"": "A"
     }
+  ],
+  "076/000 Flatten query: SELECT * FROM flatten(query={ SELECT 1 AS A, (1, 2) AS B FROM scope() })": [
+    {
+      "A": 1,
+      "B": 1
+    },
+    {
+      "A": 1,
+      "B": 2
+    }
+  ],
+  "077/000 Flatten query cartesian with 2 lists: SELECT * FROM flatten(query={ SELECT (3, 4) AS A, (1, 2) AS B FROM scope() })": [
+    {
+      "A": 3,
+      "B": 1
+    },
+    {
+      "A": 4,
+      "B": 1
+    },
+    {
+      "A": 3,
+      "B": 2
+    },
+    {
+      "A": 4,
+      "B": 2
+    }
+  ],
+  "078/000 Flatten query empty list: LET FOO \u003c= SELECT * FROM scope() WHERE FALSE": null,
+  "078/001 Flatten query empty list: SELECT * FROM flatten(query={ SELECT 1 AS A, FOO, (1, 2) AS B FROM scope() })": [
+    {
+      "A": 1,
+      "FOO": [],
+      "B": 1
+    },
+    {
+      "A": 1,
+      "FOO": [],
+      "B": 2
+    }
+  ],
+  "079/000 Flatten dict query: SELECT * FROM flatten(query={ SELECT 1 AS A, dict(E=1, F=2) AS B FROM scope() })": [
+    {
+      "A": 1,
+      "B": {
+        "E": 1,
+        "F": 2
+      }
+    }
+  ],
+  "080/000 Flatten subquery: SELECT * FROM flatten(query={ SELECT *, { SELECT * FROM range(start=1, end=3) } AS Count FROM foreach(row=[dict(A=1)]) })": [
+    {
+      "A": 1,
+      "Count": 1
+    },
+    {
+      "A": 1,
+      "Count": 2
+    },
+    {
+      "A": 1,
+      "Count": 3
+    }
+  ],
+  "081/000 Flatten stored query: LET SQ = SELECT * FROM range(start=1, end=3)": null,
+  "081/001 Flatten stored query: SELECT * FROM flatten(query={ SELECT *, SQ FROM foreach(row=[dict(A=1)]) })": [
+    {
+      "A": 1,
+      "SQ": {
+        "value": 1
+      }
+    },
+    {
+      "A": 1,
+      "SQ": {
+        "value": 2
+      }
+    },
+    {
+      "A": 1,
+      "SQ": {
+        "value": 3
+      }
+    }
   ]
 }

--- a/fixtures/vql_queries.golden
+++ b/fixtures/vql_queries.golden
@@ -91,18 +91,19 @@
       "FooColumn": 4
     }
   ],
-  "008 dict plugin: SELECT * FROM dict(env_var=15, foo=5)": [
+  "008 dict plugin: SELECT * FROM dict(env_var=15, foo=5, `field with space`='value')": [
     {
       "env_var": 15,
-      "foo": 5
+      "foo": 5,
+      "field with space": "value"
     }
   ],
-  "009 dict plugin with invalide column: SELECT no_such_column FROM dict(env_var=15, foo=5)": [
+  "009 dict plugin with invalid column: SELECT no_such_column FROM dict(env_var=15, foo=5)": [
     {
       "no_such_column": null
     }
   ],
-  "010 dict plugin with invalide column in expression: SELECT no_such_column + 'foo' FROM dict(env_var=15, foo=5)": [
+  "010 dict plugin with invalid column in expression: SELECT no_such_column + 'foo' FROM dict(env_var=15, foo=5)": [
     {
       "no_such_column + 'foo'": null
     }

--- a/protocols/protocol_div.go
+++ b/protocols/protocol_div.go
@@ -52,14 +52,14 @@ func (self DivDispatcher) Div(scope types.Scope, a types.Any, b types.Any) types
 	}
 
 	// Always convert to float to not lose preceision.
-	a_int, ok := utils.ToInt64(a)
+	a_int, ok := utils.ToFloat(a)
 	if ok {
 		b_int, ok := utils.ToFloat(b)
 		if ok {
 			if b_int == 0 {
 				return &types.Null{}
 			}
-			return float64(a_int) / b_int
+			return a_int / b_int
 		}
 	}
 

--- a/vfilter.go
+++ b/vfilter.go
@@ -1719,13 +1719,13 @@ func (self *_SymbolRef) callFunction(
 
 		} else if arg.Array != nil {
 			value := arg.Array.Reduce(ctx, scope)
-			args.Set(arg.Left, value)
+			args.Set(utils.Unquote_ident(arg.Left), value)
 
 		} else if arg.ArrayOpenBrace != "" {
-			args.Set(arg.Left, []Row{})
+			args.Set(utils.Unquote_ident(arg.Left), []Row{})
 
 		} else if arg.SubSelect != nil {
-			args.Set(arg.Left, arg.SubSelect)
+			args.Set(utils.Unquote_ident(arg.Left), arg.SubSelect)
 		}
 	}
 


### PR DESCRIPTION
Now support the Iterate() protocol and preserves column orders for * expressions.