### PR TITLE
Move aggregator context into a separate context variable

### DIFF
--- a/grouper/grouper.go
+++ b/grouper/grouper.go
@@ -58,10 +58,11 @@ func (self *DefaultGrouper) Group(
 				aggregate_ctx = aggregate_ctx_any.(*AggregateContext)
 			}
 
-			// The transform function receives its
-			// own unique context for the specific
-			// aggregate group.
-			new_scope.SetContextDict(aggregate_ctx.context)
+			// The transform function receives its own unique context
+			// for the specific aggregate group.
+			new_scope.SetContext(
+				types.AGGREGATOR_CONTEXT_TAG,
+				aggregate_ctx.context)
 
 			// Update the row with the transformed
 			// columns. Note we must materialize these

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -63,21 +63,22 @@ func (self *_destructors) RemoveDestructors() []func() {
 	return result
 }
 
-/* The scope is a common environment passed to all plugins, functions
-   and operators.
+/*
+The scope is a common environment passed to all plugins, functions and
+operators.
 
-   The scope contains all the client specific code which velocifilter
-   will use to actually execute the query. For example, clients may
-   add new plugins (See PluginGeneratorInterface{}), functions (see
-   FunctionInterface{}) or various protocol implementations to the
-   scope prior to evaluating any queries. This is the main mechanism
-   where clients may extend and specialize the VQL language.
+The scope contains all the client specific code which velocifilter
+will use to actually execute the query. For example, clients may add
+new plugins (See PluginGeneratorInterface{}), functions (see
+FunctionInterface{}) or various protocol implementations to the scope
+prior to evaluating any queries. This is the main mechanism where
+clients may extend and specialize the VQL language.
 
-   The scope also contains convenience functions allowing clients to
-   execute available protocols.
+The scope also contains convenience functions allowing clients to
+execute available protocols.
 
-   The scope may be populated with free variables that can be
-   referenced by the query.
+The scope may be populated with free variables that can be referenced
+by the query.
 */
 type Scope struct {
 	sync.Mutex
@@ -664,11 +665,6 @@ func (self _ScopeAssociative) Associative(
 		return nil, false
 	}
 	return a_scope.Resolve(b_str)
-}
-
-// Should only be used by groupers to replace the group context at once
-func (self *Scope) SetContextDict(context *ordereddict.Dict) {
-	self.dispatcher.SetContext(context)
 }
 
 func NextId() uint64 {

--- a/stored.go
+++ b/stored.go
@@ -76,8 +76,12 @@ func (self *_StoredQuery) Info(scope types.Scope, type_map *TypeMap) *PluginInfo
 func (self *_StoredQuery) Call(ctx context.Context,
 	scope types.Scope, args *ordereddict.Dict) <-chan Row {
 
+	// When running a stored query, we need to use a brand new scope
+	// with its own aggregator context to make sure that aggregate
+	// functions inside the stored query start fresh.
 	sub_scope := scope.Copy()
-	sub_scope.ClearContext()
+	sub_scope.SetContext(
+		types.AGGREGATOR_CONTEXT_TAG, ordereddict.NewDict())
 	defer sub_scope.Close()
 
 	self.checkCallingArgs(sub_scope, args)

--- a/types/scope.go
+++ b/types/scope.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"log"
 	"runtime"
+)
 
-	"github.com/Velocidex/ordereddict"
+// Aggregator functions maintain their context in this tag
+const (
+	AGGREGATOR_CONTEXT_TAG = "__ag"
 )
 
 // A ScopeMaterializer handles VQL Let Materialize operators (<=). The
@@ -29,12 +32,15 @@ type Scope interface {
 	// Copy the scope and create a subscope child.
 	Copy() Scope
 
-	// The scope context is a global k/v store
+	// The scope context is a global k/v store. It is inherited into
+	// subscopes so should be used to store global data. It is not
+	// accessible from VQL itself.
 	GetContext(name string) (Any, bool)
 	SetContext(name string, value Any)
 
-	// Replace the entire context dict.
-	SetContextDict(context *ordereddict.Dict)
+	// DEPRECATED: This should not really be used as it trashes
+	// everything in the context. It is only used when making an
+	// entirely new scope.
 	ClearContext()
 
 	// Extract debug string about the current scope state.

--- a/vfilter.go
+++ b/vfilter.go
@@ -1,5 +1,4 @@
 /*
-
 The veloci-filter (vfilter) library implements a generic SQL like
 query language.
 
@@ -87,10 +86,10 @@ implementing a registration systen in the Scope{} object.
 For example, consider a client of the library wishing to pass custom
 types in queries:
 
-  type Foo struct {
-     ...
-     bar Bar
-  }
+	type Foo struct {
+	   ...
+	   bar Bar
+	}
 
 Where both Foo and Bar are defined and produced by some other library
 which our client uses. Suppose our client wishes to allow addition of
@@ -103,28 +102,26 @@ not maintainable for heavily nested complex structs). We define a
 FooAdder{} object which implements the Addition protocol on behalf of
 the Foo object.
 
-  // This is an object which implements addition between two Foo objects.
-  type FooAdder struct{}
+	  // This is an object which implements addition between two Foo objects.
+	  type FooAdder struct{}
 
-  // This method will be run to see if this implementation is
-  // applicable. We only want to run when we add two Foo objects together.
-  func (self FooAdder) Applicable(a Any, b Any) bool {
-	_, a_ok := a.(Foo)
-	_, b_ok := b.(Foo)
-	return a_ok && b_ok
-  }
+	  // This method will be run to see if this implementation is
+	  // applicable. We only want to run when we add two Foo objects together.
+	  func (self FooAdder) Applicable(a Any, b Any) bool {
+		_, a_ok := a.(Foo)
+		_, b_ok := b.(Foo)
+		return a_ok && b_ok
+	  }
 
-  // Actually implement the addition between two Foo objects.
-  func (self FooAdder) Add(scope types.Scope, a Any, b Any) Any {
-    ... return new object (does not have to be Foo{}).
-  }
+	  // Actually implement the addition between two Foo objects.
+	  func (self FooAdder) Add(scope types.Scope, a Any, b Any) Any {
+	    ... return new object (does not have to be Foo{}).
+	  }
 
 Now clients can add this protocol to the scope before evaluating a
 query:
 
 scope := NewScope().AddProtocolImpl(FooAdder{})
-
-
 */
 package vfilter
 
@@ -1634,11 +1631,12 @@ func (self *_SymbolRef) Reduce(ctx context.Context, scope types.Scope) Any {
 			if self.Parameters != nil {
 
 				// When running a stored query as a function we need
-				// to use a brand new scope with its own context to
-				// make sure that aggregate functions inside the
-				// stored query start fresh.
+				// to use a brand new scope with its own aggregator
+				// context to make sure that aggregate functions
+				// inside the stored query start fresh.
 				subscope := scope.Copy()
-				subscope.ClearContext()
+				subscope.SetContext(
+					types.AGGREGATOR_CONTEXT_TAG, ordereddict.NewDict())
 				defer subscope.Close()
 
 				if subscope.CheckForOverflow() {


### PR DESCRIPTION
This allows aggregators to be reset without affecting other things stored in the scope context.