### PR TITLE
Bugfix: Do not implicit copy aggregate contexts.

### DIFF
--- a/functions/aggregates.go
+++ b/functions/aggregates.go
@@ -84,7 +84,7 @@ type _CountFunction struct {
 	Aggregator
 }
 
-func (self _CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *types.FunctionInfo {
+func (self *_CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *types.FunctionInfo {
 	return &types.FunctionInfo{
 		Name:        "count",
 		Doc:         "Counts the items.",
@@ -93,7 +93,7 @@ func (self _CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *typ
 	}
 }
 
-func (self _CountFunction) Call(
+func (self *_CountFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -138,7 +138,7 @@ func (self _SumFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _SumFunction) Call(
+func (self *_SumFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -183,7 +183,7 @@ func (self _MinFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _MinFunction) Call(
+func (self *_MinFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -219,7 +219,7 @@ func (self _MaxFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _MaxFunction) Call(
+func (self *_MaxFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -258,7 +258,7 @@ func (self _EnumerateFunction) Info(scope types.Scope, type_map *types.TypeMap) 
 	}
 }
 
-func (self _EnumerateFunction) Call(
+func (self *_EnumerateFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {

--- a/functions/builtin.go
+++ b/functions/builtin.go
@@ -11,11 +11,14 @@ func GetBuiltinFunctions() []types.FunctionInterface {
 		FormatFunction{},
 		_GetFunction{},
 		_EncodeFunction{},
-		_CountFunction{},
-		_SumFunction{},
-		_MinFunction{},
-		_MaxFunction{},
-		_EnumerateFunction{},
+
+		// Aggregate functions must not be implicitly copied. They are
+		// copied deliberately using vfilter.CopyFunction()
+		&_CountFunction{},
+		&_SumFunction{},
+		&_MinFunction{},
+		&_MaxFunction{},
+		&_EnumerateFunction{},
 		FormatFunction{},
 		LenFunction{},
 	}

--- a/plugins/foreach.go
+++ b/plugins/foreach.go
@@ -45,7 +45,7 @@ func (self _ForeachPluginImpl) Call(ctx context.Context,
 
 		// Create a worker pool to run the subquery in.
 		if arg.Workers > 1 {
-			scope.Log("Creating %v workers for foreach plugin\n", arg.Workers)
+			scope.Log("DEBUG:Creating %v workers for foreach plugin\n", arg.Workers)
 		}
 		pool := newWorkerPool(ctx, arg.Query, output_chan, int(arg.Workers))
 		defer pool.Close()


### PR DESCRIPTION
In some cases this causes the aggregate context to be reset.