### PR TITLE
Refactor aggregate context to be carried with the scope.

### DIFF
--- a/aggregators/aggregators.go
+++ b/aggregators/aggregators.go
@@ -1,0 +1,29 @@
+package aggregators
+
+import (
+	"sync"
+
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+type AggregatorCtx struct {
+	mu   sync.Mutex
+	data map[string]types.Any
+}
+
+func (self *AggregatorCtx) Modify(name string,
+	modifier func(old_value types.Any, pres bool) types.Any) types.Any {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	old_value, pres := self.data[name]
+	new_value := modifier(old_value, pres)
+	self.data[name] = new_value
+	return new_value
+}
+
+func NewAggregatorCtx() *AggregatorCtx {
+	return &AggregatorCtx{
+		data: make(map[string]types.Any),
+	}
+}

--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -327,7 +327,7 @@
     {
       "Y1": 6,
       "Y2": 7,
-      "Y3": 8
+      "Y3": 6
     }
   ],
   "025/000 Overflow condition - should not get stuck: LET X = 1 + X": null,
@@ -1160,42 +1160,51 @@
       }
     }
   ],
-  "082/000 Foreach query with multiple count(): SELECT * FROM foreach(row={ SELECT count() AS RowCount FROM range(start=1, end=3) }, query={ SELECT RowCount, count() AS QueryCount FROM range(start=1, step=1, end=3) })": [
+  "082/000 Foreach query with multiple count(): SELECT * FROM foreach(row={ SELECT count() AS RowCount FROM range(start=1, end=3) }, query={ SELECT RowCount, count() AS QueryCount, count() AS SecondQueryCount FROM range(start=1, step=1, end=3) })": [
     {
       "RowCount": 1,
-      "QueryCount": 1
-    },
-    {
-      "RowCount": 1,
-      "QueryCount": 2
+      "QueryCount": 1,
+      "SecondQueryCount": 1
     },
     {
       "RowCount": 1,
-      "QueryCount": 3
+      "QueryCount": 2,
+      "SecondQueryCount": 2
+    },
+    {
+      "RowCount": 1,
+      "QueryCount": 3,
+      "SecondQueryCount": 3
     },
     {
       "RowCount": 2,
-      "QueryCount": 4
+      "QueryCount": 4,
+      "SecondQueryCount": 4
     },
     {
       "RowCount": 2,
-      "QueryCount": 5
+      "QueryCount": 5,
+      "SecondQueryCount": 5
     },
     {
       "RowCount": 2,
-      "QueryCount": 6
+      "QueryCount": 6,
+      "SecondQueryCount": 6
     },
     {
       "RowCount": 3,
-      "QueryCount": 7
+      "QueryCount": 7,
+      "SecondQueryCount": 7
     },
     {
       "RowCount": 3,
-      "QueryCount": 8
+      "QueryCount": 8,
+      "SecondQueryCount": 8
     },
     {
       "RowCount": 3,
-      "QueryCount": 9
+      "QueryCount": 9,
+      "SecondQueryCount": 9
     }
   ],
   "083/000 Calling stored query with aggregators: LET Counter(Start) = SELECT count() AS Count, Start FROM range(start=1, step=1, end=3)": null,
@@ -1235,6 +1244,56 @@
     {
       "Count": 3,
       "Start": 3
+    }
+  ],
+  "084/000 Aggregate function in a parameter resets stat: LET Counter(Start) = SELECT count() AS Count, Start FROM range(start=1, step=1, end=3)": null,
+  "084/001 Aggregate function in a parameter resets stat: LET CountFunc(Start) = dict(A=count(), B=Start)": null,
+  "084/002 Aggregate function in a parameter resets stat: SELECT set_env(column=\"Eval\", value=Counter(Start=\"First Call\")), set_env(column=\"Eval2\", value=Counter(Start=\"Second Call\")), set_env(column=\"Eval3\", value=CountFunc(Start=\"First Func Call\")), set_env(column=\"Eval4\", value=CountFunc(Start=\"Second Func Call\")) FROM scope()": [
+    {
+      "set_env(column=\"Eval\", value=Counter(Start=\"First Call\"))": true,
+      "set_env(column=\"Eval2\", value=Counter(Start=\"Second Call\"))": true,
+      "set_env(column=\"Eval3\", value=CountFunc(Start=\"First Func Call\"))": true,
+      "set_env(column=\"Eval4\", value=CountFunc(Start=\"Second Func Call\"))": true
+    }
+  ],
+  "084/003 Aggregate function in a parameter resets stat: SELECT RootEnv.Eval AS FirstCall, RootEnv.Eval2 AS SecondCall, RootEnv.Eval3 AS FirstFuncCall, RootEnv.Eval4 AS SecondFuncCall FROM scope()": [
+    {
+      "FirstCall": [
+        {
+          "Count": 1,
+          "Start": "First Call"
+        },
+        {
+          "Count": 2,
+          "Start": "First Call"
+        },
+        {
+          "Count": 3,
+          "Start": "First Call"
+        }
+      ],
+      "SecondCall": [
+        {
+          "Count": 1,
+          "Start": "Second Call"
+        },
+        {
+          "Count": 2,
+          "Start": "Second Call"
+        },
+        {
+          "Count": 3,
+          "Start": "Second Call"
+        }
+      ],
+      "FirstFuncCall": {
+        "A": 1,
+        "B": "First Func Call"
+      },
+      "SecondFuncCall": {
+        "A": 1,
+        "B": "Second Func Call"
+      }
     }
   ]
 }

--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -1159,5 +1159,82 @@
         "value": 3
       }
     }
+  ],
+  "082/000 Foreach query with multiple count(): SELECT * FROM foreach(row={ SELECT count() AS RowCount FROM range(start=1, end=3) }, query={ SELECT RowCount, count() AS QueryCount FROM range(start=1, step=1, end=3) })": [
+    {
+      "RowCount": 1,
+      "QueryCount": 1
+    },
+    {
+      "RowCount": 1,
+      "QueryCount": 2
+    },
+    {
+      "RowCount": 1,
+      "QueryCount": 3
+    },
+    {
+      "RowCount": 2,
+      "QueryCount": 4
+    },
+    {
+      "RowCount": 2,
+      "QueryCount": 5
+    },
+    {
+      "RowCount": 2,
+      "QueryCount": 6
+    },
+    {
+      "RowCount": 3,
+      "QueryCount": 7
+    },
+    {
+      "RowCount": 3,
+      "QueryCount": 8
+    },
+    {
+      "RowCount": 3,
+      "QueryCount": 9
+    }
+  ],
+  "083/000 Calling stored query with aggregators: LET Counter(Start) = SELECT count() AS Count, Start FROM range(start=1, step=1, end=3)": null,
+  "083/001 Calling stored query with aggregators: SELECT * FROM foreach(row={ SELECT count() AS RowCount FROM range(start=1, end=3) }, query={ SELECT * FROM Counter(Start=RowCount) })": [
+    {
+      "Count": 1,
+      "Start": 1
+    },
+    {
+      "Count": 2,
+      "Start": 1
+    },
+    {
+      "Count": 3,
+      "Start": 1
+    },
+    {
+      "Count": 1,
+      "Start": 2
+    },
+    {
+      "Count": 2,
+      "Start": 2
+    },
+    {
+      "Count": 3,
+      "Start": 2
+    },
+    {
+      "Count": 1,
+      "Start": 3
+    },
+    {
+      "Count": 2,
+      "Start": 3
+    },
+    {
+      "Count": 3,
+      "Start": 3
+    }
   ]
 }

--- a/functions/aggregates.go
+++ b/functions/aggregates.go
@@ -84,7 +84,7 @@ type _CountFunction struct {
 	Aggregator
 }
 
-func (self _CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *types.FunctionInfo {
+func (self *_CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *types.FunctionInfo {
 	return &types.FunctionInfo{
 		Name:        "count",
 		Doc:         "Counts the items.",
@@ -93,7 +93,7 @@ func (self _CountFunction) Info(scope types.Scope, type_map *types.TypeMap) *typ
 	}
 }
 
-func (self _CountFunction) Call(
+func (self *_CountFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -138,7 +138,7 @@ func (self _SumFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _SumFunction) Call(
+func (self *_SumFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -183,7 +183,7 @@ func (self _MinFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _MinFunction) Call(
+func (self *_MinFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -219,7 +219,7 @@ func (self _MaxFunction) Info(scope types.Scope, type_map *types.TypeMap) *types
 	}
 }
 
-func (self _MaxFunction) Call(
+func (self *_MaxFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {
@@ -258,7 +258,7 @@ func (self _EnumerateFunction) Info(scope types.Scope, type_map *types.TypeMap) 
 	}
 }
 
-func (self _EnumerateFunction) Call(
+func (self *_EnumerateFunction) Call(
 	ctx context.Context,
 	scope types.Scope,
 	args *ordereddict.Dict) types.Any {

--- a/functions/builtin.go
+++ b/functions/builtin.go
@@ -11,11 +11,14 @@ func GetBuiltinFunctions() []types.FunctionInterface {
 		FormatFunction{},
 		_GetFunction{},
 		_EncodeFunction{},
-		_CountFunction{},
-		_SumFunction{},
-		_MinFunction{},
-		_MaxFunction{},
-		_EnumerateFunction{},
+
+		// Aggregate functions must not be implicitly copied. They are
+		// copied deliberately using vfilter.CopyFunction()
+		&_CountFunction{},
+		&_SumFunction{},
+		&_MinFunction{},
+		&_MaxFunction{},
+		&_EnumerateFunction{},
 		FormatFunction{},
 		LenFunction{},
 	}

--- a/plugins/foreach.go
+++ b/plugins/foreach.go
@@ -45,7 +45,7 @@ func (self _ForeachPluginImpl) Call(ctx context.Context,
 
 		// Create a worker pool to run the subquery in.
 		if arg.Workers > 1 {
-			scope.Log("Creating %v workers for foreach plugin\n", arg.Workers)
+			scope.Log("DEBUG:Creating %v workers for foreach plugin\n", arg.Workers)
 		}
 		pool := newWorkerPool(ctx, arg.Query, output_chan, int(arg.Workers))
 		defer pool.Close()

--- a/scope/aggregators.go
+++ b/scope/aggregators.go
@@ -1,0 +1,29 @@
+package scope
+
+import (
+	"sync"
+
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+type AggregatorCtx struct {
+	mu   sync.Mutex
+	data map[string]types.Any
+}
+
+func (self *AggregatorCtx) Modify(name string,
+	modifier func(old_value types.Any, pres bool) types.Any) types.Any {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
+	old_value, pres := self.data[name]
+	new_value := modifier(old_value, pres)
+	self.data[name] = new_value
+	return new_value
+}
+
+func NewAggregatorCtx() *AggregatorCtx {
+	return &AggregatorCtx{
+		data: make(map[string]types.Any),
+	}
+}

--- a/scope/fixtures/TestDestructors.golden
+++ b/scope/fixtures/TestDestructors.golden
@@ -39,10 +39,10 @@
   ],
   "009 Multiple functions: SELECT destructor(name='one'), destructor(name='two'), destructor(name='three') FROM scope() - markers": [
     "Func Open one 1",
-    "Func Open two 1",
-    "Func Open three 1",
-    "Func Close three 1",
-    "Func Close two 1",
+    "Func Open two 2",
+    "Func Open three 3",
+    "Func Close three 3",
+    "Func Close two 2",
     "Func Close one 1"
   ]
 }

--- a/stored.go
+++ b/stored.go
@@ -80,8 +80,7 @@ func (self *_StoredQuery) Call(ctx context.Context,
 	// with its own aggregator context to make sure that aggregate
 	// functions inside the stored query start fresh.
 	sub_scope := scope.Copy()
-	sub_scope.SetContext(
-		types.AGGREGATOR_CONTEXT_TAG, ordereddict.NewDict())
+	sub_scope.SetAggregatorCtx(nil)
 	defer sub_scope.Close()
 
 	self.checkCallingArgs(sub_scope, args)

--- a/types/aggregators.go
+++ b/types/aggregators.go
@@ -1,0 +1,8 @@
+package types
+
+type AggregatorCtx interface {
+	// Modify the context under lock. If there is no existing value,
+	// old_value will be nil and pres will be false. You can use this
+	// to read the old value as well by just returning it.
+	Modify(name string, modifier func(old_value Any, pres bool) Any) Any
+}

--- a/types/scope.go
+++ b/types/scope.go
@@ -6,11 +6,6 @@ import (
 	"runtime"
 )
 
-// Aggregator functions maintain their context in this tag
-const (
-	AGGREGATOR_CONTEXT_TAG = "__ag"
-)
-
 // A ScopeMaterializer handles VQL Let Materialize operators (<=). The
 // returned object will be added to the scope and can be accessed in
 // subsequent queries. This allows users of vfilter the ability to
@@ -42,6 +37,15 @@ type Scope interface {
 	// everything in the context. It is only used when making an
 	// entirely new scope.
 	ClearContext()
+
+	// The aggregator context is used by aggregator functions to store
+	// context within a query block.
+	GetAggregatorCtx() AggregatorCtx
+
+	// Creates a new AggregatorCtx on this scope. This is used by VQL
+	// when entering a new semantic scope where aggregators need to be
+	// reset.
+	SetAggregatorCtx(ctx AggregatorCtx)
 
 	// Extract debug string about the current scope state.
 	PrintVars() string

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -1,0 +1,3 @@
+package utils
+
+func DlvBreak() {}

--- a/vfilter.go
+++ b/vfilter.go
@@ -1610,6 +1610,11 @@ func (self *_SymbolRef) Reduce(ctx context.Context, scope types.Scope) Any {
 		// it.
 		case *StoredExpression:
 			subscope := scope.Copy()
+
+			// Only create a new context for called functions.
+			if self.Called {
+				subscope.SetAggregatorCtx(nil)
+			}
 			defer subscope.Close()
 
 			if subscope.CheckForOverflow() {

--- a/vfilter.go
+++ b/vfilter.go
@@ -137,7 +137,6 @@ import (
 	"github.com/alecthomas/participle"
 	"github.com/alecthomas/participle/lexer"
 	errors "github.com/pkg/errors"
-	"www.velocidex.com/golang/vfilter/functions"
 	"www.velocidex.com/golang/vfilter/scope"
 	scope_module "www.velocidex.com/golang/vfilter/scope"
 	"www.velocidex.com/golang/vfilter/types"
@@ -1621,6 +1620,7 @@ func (self *_SymbolRef) Reduce(ctx context.Context, scope types.Scope) Any {
 				ctx, scope))
 
 			scope.GetStats().IncFunctionsCalled()
+
 			return t.Reduce(ctx, subscope)
 
 		case StoredQuery:
@@ -1635,8 +1635,8 @@ func (self *_SymbolRef) Reduce(ctx context.Context, scope types.Scope) Any {
 				// context to make sure that aggregate functions
 				// inside the stored query start fresh.
 				subscope := scope.Copy()
-				subscope.SetContext(
-					types.AGGREGATOR_CONTEXT_TAG, ordereddict.NewDict())
+				subscope.SetAggregatorCtx(nil)
+
 				defer subscope.Close()
 
 				if subscope.CheckForOverflow() {
@@ -1799,12 +1799,6 @@ func CopyFunction(in types.Any) types.FunctionInterface {
 
 	in_value := reflect.Indirect(reflect.ValueOf(in))
 	result := reflect.New(in_value.Type()).Interface()
-
-	// Handle aggregate functions specifically.
-	aggregate_func, ok := result.(functions.AggregatorInterface)
-	if ok {
-		aggregate_func.SetNewAggregator()
-	}
 
 	return result.(types.FunctionInterface)
 }

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -745,8 +745,10 @@ var multiVQLTest = []vqlTest{
 	{"LET with expression lazy - string concat",
 		"LET X = 'hello' SELECT X + 'world', 'world' + X, 'hello world' =~ X FROM scope()"},
 
-	// count() increments every time it is called proving X is
-	// lazy and will be re-evaluated each time.
+	// count() increments every time it is called proving X is lazy
+	// and will be re-evaluated each time. NOTE: Referencing variables
+	// without calling them **does not** create an isolated scope. In
+	// this way LET X is different than LET X(Y)
 	{"Lazy expression in arrays",
 		"LET X = count() SELECT (1, X), dict(foo=X, bar=[1,X]) FROM scope()"},
 
@@ -777,9 +779,13 @@ var multiVQLTest = []vqlTest{
 	{"Lazy expression evaluates in caller's scope",
 		"LET X(foo) = 1 + foo SELECT X(foo= foo + 1 ), foo FROM test()"},
 
-	{"Calling lazy expressions as functions allows access to global scope",
-		"LET Xk = 5 LET Y = Xk + count() SELECT Y AS Y1, Y AS Y2, Y() AS Y3 FROM scope()"},
-
+	// Calling a symbol will reset aggregator context, but simply
+	// referencing it will not. Therefore Y1 = 6, Y2 = 7 but Y3 = 6 again.
+	{"Calling lazy expressions as functions allows access to global scope", `
+LET Xk = 5
+LET Y = Xk + count()
+SELECT Y AS Y1, Y AS Y2, Y() AS Y3 FROM scope()
+`},
 	{"Overflow condition - should not get stuck",
 		"LET X = 1 + X SELECT X(X=1), X FROM test()"},
 
@@ -1237,7 +1243,7 @@ SELECT * FROM foreach(row={
    SELECT count() AS RowCount
    FROM range(start=1, end=3)
 }, query={
-   SELECT RowCount, count() AS QueryCount
+   SELECT RowCount, count() AS QueryCount, count() AS SecondQueryCount
    FROM range(start=1, step=1, end=3)
 })
 `},
@@ -1253,6 +1259,25 @@ SELECT * FROM foreach(row={
 }, query={
    SELECT * FROM Counter(Start=RowCount)
 })
+`},
+
+	// Each time that Counter() is called should reset.
+	// Each time that CountFunc() is called should reset.
+	{"Aggregate function in a parameter resets stat", `
+LET Counter(Start) = SELECT count() AS Count, Start
+  FROM range(start=1, step=1, end=3)
+
+LET CountFunc(Start) = dict(A=count(), B=Start)
+
+SELECT set_env(column="Eval", value=Counter(Start="First Call")),
+       set_env(column="Eval2", value=Counter(Start="Second Call")),
+       set_env(column="Eval3", value=CountFunc(Start="First Func Call")),
+       set_env(column="Eval4", value=CountFunc(Start="Second Func Call"))
+FROM scope()
+
+SELECT RootEnv.Eval AS FirstCall, RootEnv.Eval2 AS SecondCall,
+       RootEnv.Eval3 AS FirstFuncCall, RootEnv.Eval4 AS SecondFuncCall
+FROM scope()
 `},
 }
 


### PR DESCRIPTION
  1. Each aggregate function instance in the AST carries a unique                                                                                                           
     ID. This allows the function to store its own state in the                                                                                                             
     aggregate context without interference from other instances of                                                                                                         
     the same function (e.g. having two count() instaces is OK)                                                                                                             

  2. The scope may contain a reference to an AggregatorCtx                                                                                                                  
     object. This object manages access to the aggregate                                                                                                                    
     context. The main method that should be used is Modify() which                                                                                                         
     mofidies the context under lock.                                                                                                                                       

  3. When the scope spawns a child scope, the child scope does not                                                                                                          
     have its own AggregatorCtx, instead chasing its parent to find                                                                                                         
     one. This allows aggregate functions within the scope to see                                                                                                           
     the wider AggregatorCtx which controls the entire query clause.                                                                                                        

  4. When the query runs in an isolated context, the AggregatorCtx                                                                                                          
     is recreated at the calling scope. This allows isolated scopes                                                                                                         
     to reset the AggregatorCtx. For example, when calling a LET                                                                                                            
     defined function, a new context is created.                                                                                                                            

  5. If a GROUP BY query, the Grouper will create a new                                                                                                                     
     AggregatorCtx for each bin. This allows aggregate functions to                                                                                                         
     apply on each group separately.  