### PR TITLE
Bugfix: Create each row in a child scope.

### DIFF
--- a/fixtures/multi_vql_queries.golden
+++ b/fixtures/multi_vql_queries.golden
@@ -1295,5 +1295,21 @@
         "B": "Second Func Call"
       }
     }
+  ],
+  "085/000 Test Scope Clearing: LET Data \u003c= (dict(A=1), dict(B=2))": null,
+  "085/001 Test Scope Clearing: LET s = scope()": null,
+  "085/002 Test Scope Clearing: SELECT s.A, A, s.B, B FROM Data": [
+    {
+      "s.A": 1,
+      "A": 1,
+      "s.B": null,
+      "B": null
+    },
+    {
+      "s.A": null,
+      "A": null,
+      "s.B": 2,
+      "B": 2
+    }
   ]
 }

--- a/functions/builtin.go
+++ b/functions/builtin.go
@@ -21,5 +21,6 @@ func GetBuiltinFunctions() []types.FunctionInterface {
 		&_EnumerateFunction{},
 		FormatFunction{},
 		LenFunction{},
+		_Scope{},
 	}
 }

--- a/functions/scope.go
+++ b/functions/scope.go
@@ -1,0 +1,27 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/Velocidex/ordereddict"
+	"www.velocidex.com/golang/vfilter/types"
+)
+
+type _Scope struct{}
+
+func (self _Scope) Call(
+	ctx context.Context,
+	scope types.Scope,
+	args *ordereddict.Dict) types.Any {
+
+	return scope
+}
+
+func (self _Scope) Info(scope types.Scope,
+	type_map *types.TypeMap) *types.FunctionInfo {
+
+	return &types.FunctionInfo{
+		Name: "scope",
+		Doc:  "return the scope.",
+	}
+}

--- a/vfilter_test.go
+++ b/vfilter_test.go
@@ -1278,6 +1278,11 @@ FROM scope()
 SELECT RootEnv.Eval AS FirstCall, RootEnv.Eval2 AS SecondCall,
        RootEnv.Eval3 AS FirstFuncCall, RootEnv.Eval4 AS SecondFuncCall
 FROM scope()
+`}, {"Test Scope Clearing", `
+LET Data <= (dict(A=1), dict(B=2))
+LET s = scope()
+
+SELECT s.A, A, s.B, B FROM Data
 `},
 }
 
@@ -1475,7 +1480,7 @@ func TestMultiVQLQueries(t *testing.T) {
 	// Store the result in ordered dict so we have a consistent golden file.
 	result := ordereddict.NewDict()
 	for i, testCase := range multiVQLTest {
-		if false && i != 84 {
+		if false && i != 85 {
 			continue
 		}
 		scope := makeTestScope()


### PR DESCRIPTION
If we dont use a child scope, vars are all appended to the parent scope which causes a memory leak.