### PR TITLE
Allow destructors to reschedule themselves on the same scope.

### DIFF
--- a/protocols/protocol_associative.go
+++ b/protocols/protocol_associative.go
@@ -36,7 +36,7 @@ func (self *AssociativeDispatcher) Associative(
 	ctx := context.Background()
 
 	if types.IsNil(a) {
-		return types.Null{}, false
+		return types.Null{}, true
 	}
 
 	b_str, ok := utils.ToString(b)


### PR DESCRIPTION
Sometimes it is difficult to predict the required order of destructors. This PR allows the destructors to reschedule themselves on the same scope to allow other destructors to go first.