### PR TITLE
Bugfix: Addition memory check accidentally multiplied

### DIFF
--- a/functions/functions.go
+++ b/functions/functions.go
@@ -74,7 +74,7 @@ type _SubSelectFunctionArgs struct {
 
 type _SplitFunctionArgs struct {
 	String     string `vfilter:"required,field=string,doc=The value to split"`
-	Sep        string `vfilter:"optional,field=sep,doc=The separator that will be used to split"`
+	Sep        string `vfilter:"optional,field=sep,doc=The separator regex that will be used to split"`
 	Sep_string string `vfilter:"optional,field=sep_string,doc=The separator as string that will be used to split"`
 }
 type _SplitFunction struct{}

--- a/protocols/protocol_add.go
+++ b/protocols/protocol_add.go
@@ -56,9 +56,10 @@ func (self AddDispatcher) Add(scope types.Scope, a types.Any, b types.Any) types
 		if ok {
 			// Estimate how much memory we will use when adding the
 			// string
-			memory := len(t) * len(b_str)
+			memory := len(t) + len(b_str)
 			if memory > 100000000 { // 100mb
-				scope.Log("Multiply Str x Int exceeded memory limits")
+				scope.Log("Adding Str + Str exceeded memory limits. LH Str %v + RH Str %v = %v",
+					len(t), len(b_str), len(t)+len(b_str))
 				return &types.Null{}
 			}
 

--- a/protocols/protocol_mul.go
+++ b/protocols/protocol_mul.go
@@ -34,9 +34,10 @@ func (self MulDispatcher) Mul(scope types.Scope, a types.Any, b types.Any) types
 		b_int, ok := utils.ToInt64(b)
 		if ok {
 			// Estimate how much memory we will use when duplicating the string
-			memory := len(t) * int(b_int)
+			memory := uint64(len(t)) * uint64(b_int)
 			if memory > 100000000 { // 100mb
-				scope.Log("Multiply Str x Int exceeded memory limits")
+				scope.Log("Multiply Str x Int exceeded memory limits. Len Str %v * Count %v = %v",
+					len(t), int(b_int), memory)
 				return &types.Null{}
 			}
 			return strings.Repeat(t, int(b_int))


### PR DESCRIPTION
This was a copy paste bug from the multiple case, causing VQL to reject the operation much sooner than intended.