### PR TITLE
Bugfix: Merge callsites when visiting args

### DIFF
--- a/arg_parser/parser.go
+++ b/arg_parser/parser.go
@@ -213,7 +213,7 @@ func stringParser(ctx context.Context, scope types.Scope,
 		// Convert integer things to what they normally would look
 		// like as a string
 	case uint64, int64, uint32, int32, uint16,
-		int16, uint8, int8, float64, float32:
+		int16, uint8, int8, float64, float32, int:
 		return fmt.Sprintf("%v", arg), nil
 
 	default:

--- a/visitor.go
+++ b/visitor.go
@@ -98,6 +98,7 @@ func NewVisitor(scope types.Scope, options FormatOptions) *Visitor {
 // Merge results from the in visitor to this visitor.
 func (self *Visitor) merge(in *Visitor) {
 	self.Fragments = append([]string{}, in.Fragments...)
+	self.CallSites = append(self.CallSites, in.CallSites...)
 	self.line_breaks = in.line_breaks
 	self.indents = append([]int{}, in.indents...)
 	self.pos = in.pos


### PR DESCRIPTION
This would cause callsites to be lost within args subqueries which affected the verifier