### PR TITLE
Refactor: Consolidate Inspect/Outline analysis into the shared Visitor

### DIFF
--- a/inspect.go
+++ b/inspect.go
@@ -111,8 +111,8 @@ func Inspect(vql *VQL) *Inspection {
 		CollectDefinitionSites: true,
 
 		// We only care about the analysis results, not the
-		// formatting. AnalysisOnly skips the formatter's
-		// look-ahead copies so each node is visited once.
+		// formatting. AnalysisOnly skips the look-ahead copies
+		// the formatter would make, so each node is visited once.
 		AnalysisOnly: true,
 	})
 	visitor.Visit(vql)

--- a/inspect.go
+++ b/inspect.go
@@ -22,13 +22,24 @@ import (
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
-// This file provides an exported, position-aware walker over the VQL AST.
+// This file provides an exported, position-aware analysis of the VQL
+// AST: the plugin calls, function calls, symbol references and LET
+// definitions in a parsed query.
 //
-// The grammar node types (like _Select, _AndExpression and _SymbolRef) are
-// unexported, which makes it impossible for external packages to traverse
-// the AST directly. The Inspect() function below is the sanctioned way for
-// tooling (for example the VQL language server) to walk a parsed query and
+// The grammar node types (like _Select, _AndExpression and _SymbolRef)
+// are unexported, which makes it impossible for external packages to
+// traverse the AST directly. The Inspect() function below is the
+// sanctioned way for tooling (for example the VQL language server) to
 // learn about plugin calls, function calls and argument positions.
+//
+// Inspect() does not walk the grammar itself. It is a thin adapter
+// over the package's single traversal mechanism (the Visitor): the
+// visitor collects call sites, definition sites and symbol references
+// as it descends the tree, and Inspect() translates its (now
+// position-aware) collections into the exported analysis types below.
+// Keeping one descent of the grammar - instead of one per analysis -
+// is what allows Inspect() and Outline() to stay in sync with the
+// parser without duplicating its tree walk.
 
 // ArgInfo describes a single keyword argument to a plugin or function call.
 type ArgInfo struct {
@@ -41,9 +52,6 @@ type ArgInfo struct {
 }
 
 // CallInfo describes a plugin or function invocation.
-//
-// Note: this shadows nothing in the package; the reformat-oriented
-// CallInfo lives in visitor.go and is unrelated.
 type CallInfo struct {
 	// Name is the full dotted name (e.g. "Artifact.Windows.Sys.Users").
 	Name string
@@ -56,7 +64,8 @@ type CallInfo struct {
 	EndPos lexer.Position
 	// Args holds the keyword arguments.
 	Args []ArgInfo
-	// FreeForm is set if the callable accepts arbitrary keyword args.
+	// FreeForm is reserved; it is always false for parsed queries (the
+	// registry decides whether a callable accepts arbitrary args).
 	FreeForm bool
 }
 
@@ -97,209 +106,54 @@ func Inspect(vql *VQL) *Inspection {
 		return result
 	}
 
-	if vql.Let != "" {
-		result.Lets = append(result.Lets, LetInfo{
-			Name: vql.Let,
-			Pos:  vql.Pos,
-		})
+	visitor := NewVisitor(NewScope(), FormatOptions{
+		CollectCallSites:       true,
+		CollectDefinitionSites: true,
+
+		// We only care about the analysis results, not the
+		// formatting. AnalysisOnly skips the formatter's
+		// look-ahead copies so each node is visited once.
+		AnalysisOnly: true,
+	})
+	visitor.Visit(vql)
+
+	// The visitor records every callable it meets in a single
+	// list, tagged with its Type ("symbol", "function" or
+	// "plugin"). Split it into the two exported collections.
+	for _, cs := range visitor.CallSites {
+		switch cs.Type {
+		case "symbol":
+			result.Symbols = append(result.Symbols, SymbolInfo{
+				Name:   cs.Name,
+				Pos:    cs.Pos,
+				EndPos: cs.EndPos,
+			})
+
+		case "function", "plugin":
+			call := CallInfo{
+				Name:     cs.Name,
+				IsPlugin: cs.Type == "plugin",
+				Pos:      cs.Pos,
+				EndPos:   cs.EndPos,
+			}
+			for i, arg := range cs.Args {
+				info := ArgInfo{Name: arg}
+				if i < len(cs.ArgPositions) {
+					info.Pos = cs.ArgPositions[i].Pos
+					info.EndPos = cs.ArgPositions[i].EndPos
+				}
+				call.Args = append(call.Args, info)
+			}
+			result.Calls = append(result.Calls, call)
+		}
 	}
 
-	// LET X = SELECT ... or LET X = <expr>
-	if vql.StoredQuery != nil {
-		result.inspectSelect(vql.StoredQuery)
-	}
-	if vql.Expression != nil {
-		result.inspectAndExpression(vql.Expression)
-	}
-	// Plain SELECT statement.
-	if vql.Query != nil {
-		result.inspectSelect(vql.Query)
+	for _, def := range visitor.Definitions {
+		result.Lets = append(result.Lets, LetInfo{
+			Name: def.Name,
+			Pos:  def.Pos,
+		})
 	}
 
 	return result
-}
-
-func (self *Inspection) inspectSelect(select_ *_Select) {
-	if select_ == nil {
-		return
-	}
-
-	// Column expressions.
-	if select_.SelectExpression != nil {
-		for _, column := range select_.SelectExpression.Expressions {
-			self.inspectAliasedExpression(column)
-		}
-	}
-
-	// FROM clause plugin.
-	if select_.From != nil {
-		plugin := &select_.From.Plugin
-		if plugin.Name != "" {
-			call := CallInfo{
-				Name:     plugin.Name,
-				IsPlugin: true,
-				Pos:      plugin.Pos,
-				EndPos:   plugin.EndPos,
-			}
-			for _, arg := range plugin.Args {
-				call.Args = append(call.Args, self.argToSite(arg))
-			}
-			self.Calls = append(self.Calls, call)
-		}
-	}
-
-	// WHERE clause.
-	if select_.Where != nil {
-		self.inspectCommaExpression(select_.Where)
-	}
-
-	// GROUP BY clause.
-	if select_.GroupBy != nil {
-		self.inspectCommaExpression(select_.GroupBy)
-	}
-}
-
-func (self *Inspection) inspectAliasedExpression(expr *_AliasedExpression) {
-	if expr == nil {
-		return
-	}
-	if expr.SubSelect != nil {
-		self.inspectSelect(expr.SubSelect)
-	}
-	if expr.Expression != nil {
-		self.inspectAndExpression(expr.Expression)
-	}
-}
-
-func (self *Inspection) argToSite(arg *_Args) ArgInfo {
-	site := ArgInfo{
-		Name:   arg.Left,
-		Pos:    arg.Pos,
-		EndPos: arg.EndPos,
-	}
-	if arg.SubSelect != nil {
-		self.inspectSelect(arg.SubSelect)
-	}
-	if arg.Right != nil {
-		self.inspectAndExpression(arg.Right)
-	}
-	if arg.Array != nil {
-		self.inspectCommaExpression(arg.Array)
-	}
-	return site
-}
-
-func (self *Inspection) inspectCommaExpression(expr *_CommaExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectAndExpression(expr.Left)
-	for _, term := range expr.Right {
-		self.inspectAndExpression(term.Term)
-	}
-}
-
-func (self *Inspection) inspectAndExpression(expr *_AndExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectOrExpression(expr.Left)
-	for _, term := range expr.Right {
-		self.inspectOrExpression(term.Term)
-	}
-}
-
-func (self *Inspection) inspectOrExpression(expr *_OrExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectConditionOperand(expr.Left)
-	for _, term := range expr.Right {
-		self.inspectConditionOperand(term.Term)
-	}
-}
-
-func (self *Inspection) inspectConditionOperand(expr *_ConditionOperand) {
-	if expr == nil {
-		return
-	}
-	if expr.Not != nil {
-		self.inspectConditionOperand(expr.Not)
-	}
-	self.inspectAdditionExpression(expr.Left)
-	if expr.Right != nil {
-		self.inspectAdditionExpression(expr.Right.Right)
-	}
-}
-
-func (self *Inspection) inspectAdditionExpression(expr *_AdditionExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectMultiplicationExpression(expr.Left)
-	for _, term := range expr.Right {
-		self.inspectMultiplicationExpression(term.Term)
-	}
-}
-
-func (self *Inspection) inspectMultiplicationExpression(expr *_MultiplicationExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectMemberExpression(expr.Left)
-	for _, term := range expr.Right {
-		self.inspectValue(term.Factor)
-	}
-}
-
-func (self *Inspection) inspectMemberExpression(expr *_MemberExpression) {
-	if expr == nil {
-		return
-	}
-	self.inspectValue(expr.Left)
-	for _, term := range expr.Right {
-		if term.Index != nil {
-			self.inspectValue(term.Index)
-		}
-		if term.RangeEnd != nil {
-			self.inspectValue(term.RangeEnd)
-		}
-	}
-}
-
-func (self *Inspection) inspectValue(value *_Value) {
-	if value == nil {
-		return
-	}
-	if value.SymbolRef != nil {
-		self.inspectSymbolRef(value.SymbolRef)
-	}
-	if value.Subexpression != nil {
-		self.inspectCommaExpression(value.Subexpression)
-	}
-}
-
-func (self *Inspection) inspectSymbolRef(ref *_SymbolRef) {
-	if ref == nil {
-		return
-	}
-	if ref.Called {
-		// A function call.
-		call := CallInfo{
-			Name:   ref.Symbol,
-			Pos:    ref.Pos,
-			EndPos: ref.EndPos,
-		}
-		for _, arg := range ref.Parameters {
-			call.Args = append(call.Args, self.argToSite(arg))
-		}
-		self.Calls = append(self.Calls, call)
-	} else {
-		// A bare symbol reference (column, LET var, or unknown).
-		self.Symbols = append(self.Symbols, SymbolInfo{
-			Name:   ref.Symbol,
-			Pos:    ref.Pos,
-			EndPos: ref.EndPos,
-		})
-	}
 }

--- a/outline.go
+++ b/outline.go
@@ -27,8 +27,18 @@ import (
 // editor's symbol navigator).
 //
 // Like Inspect() it is exported because the grammar node types are
-// unexported; Outline() is the sanctioned way for tooling to learn about
-// the structure of a query.
+// unexported; Outline() is the sanctioned way for tooling to learn
+// about the structure of a query.
+//
+// Outline() does not walk the grammar itself. It is a thin adapter
+// over the package's single traversal mechanism (the Visitor): when
+// constructed with CollectOutline, the visitor builds the OutlineInfo
+// tree incrementally as it descends the AST - LET statements, queries
+// and columns push nodes, and function calls inside column
+// expressions become children - and Outline() returns the root it
+// produced. Keeping one descent of the grammar - instead of one per
+// analysis - is what allows Outline() and Inspect() to stay in sync
+// with the parser without duplicating its tree walk.
 
 // OutlineKind classifies an outline entry.
 type OutlineKind string
@@ -59,6 +69,13 @@ type OutlineInfo struct {
 	EndPos lexer.Position
 	// Children are nested symbols.
 	Children []*OutlineInfo
+
+	// isExpression marks the synthetic node the visitor creates for
+	// a LET statement whose value is a plain expression rather than
+	// a query. Function calls are outlined beneath it just like they
+	// are beneath a column. This is an internal marker; callers never
+	// need to set it.
+	isExpression bool
 }
 
 // Outline walks a parsed VQL statement and returns the root outline node.
@@ -73,196 +90,15 @@ func Outline(vql *VQL) *OutlineInfo {
 		return nil
 	}
 
-	if vql.Let != "" {
-		root := &OutlineInfo{
-			Name:   vql.Let,
-			Kind:   OutlineKindLet,
-			Pos:    vql.Pos,
-			EndPos: vql.EndPos,
-		}
-		if vql.StoredQuery != nil {
-			root.Children = append(root.Children, outlineSelect(vql.StoredQuery))
-		}
-		if vql.Expression != nil {
-			root.Children = append(root.Children, outlineExpression(vql.Expression))
-		}
-		return root
-	}
+	visitor := NewVisitor(NewScope(), FormatOptions{
+		CollectOutline: true,
 
-	if vql.Query != nil {
-		return outlineSelect(vql.Query)
-	}
-	return nil
-}
+		// We only care about the outline, not the formatting.
+		// AnalysisOnly skips the formatter's look-ahead copies so
+		// the outline stack is maintained on the visitor itself.
+		AnalysisOnly: true,
+	})
+	visitor.Visit(vql)
 
-func outlineSelect(select_ *_Select) *OutlineInfo {
-	if select_ == nil {
-		return nil
-	}
-
-	root := &OutlineInfo{
-		Kind:   OutlineKindQuery,
-		Pos:    select_.Pos,
-		EndPos: select_.EndPos,
-	}
-	if select_.From != nil && select_.From.Plugin.Name != "" {
-		root.Name = select_.From.Plugin.Name
-	}
-
-	if select_.SelectExpression != nil {
-		for _, column := range select_.SelectExpression.Expressions {
-			child := outlineColumn(column)
-			if child != nil {
-				root.Children = append(root.Children, child)
-			}
-		}
-	}
-	return root
-}
-
-func outlineColumn(expr *_AliasedExpression) *OutlineInfo {
-	if expr == nil {
-		return nil
-	}
-
-	// A subquery used directly as a column (SELECT (SELECT ...)).
-	if expr.SubSelect != nil {
-		return outlineSelect(expr.SubSelect)
-	}
-
-	entry := &OutlineInfo{
-		Kind:   OutlineKindColumn,
-		Pos:    expr.Pos,
-		EndPos: expr.EndPos,
-	}
-	if expr.As != "" {
-		entry.Name = expr.As
-	}
-	if expr.Expression != nil {
-		entry.Children = outlineExpressionChildren(expr.Expression)
-	}
-	return entry
-}
-
-// outlineExpression builds an entry for a bare expression (used when a
-// LET is assigned a non-query value). It carries any nested function calls
-// as children.
-func outlineExpression(expr *_AndExpression) *OutlineInfo {
-	if expr == nil {
-		return nil
-	}
-	entry := &OutlineInfo{
-		Kind:   OutlineKindQuery,
-		Pos:    expr.Pos,
-		EndPos: expr.EndPos,
-	}
-	entry.Children = outlineExpressionChildren(expr)
-	return entry
-}
-
-// outlineExpressionChildren returns the function calls nested inside an
-// expression tree.
-func outlineExpressionChildren(expr *_AndExpression) []*OutlineInfo {
-	children := []*OutlineInfo{}
-	collectExpressionFunctions(expr, &children)
-	return children
-}
-
-func collectExpressionFunctions(expr *_AndExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectOrFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		collectOrFunctions(term.Term, children)
-	}
-}
-
-func collectOrFunctions(expr *_OrExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectConditionFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		collectConditionFunctions(term.Term, children)
-	}
-}
-
-func collectConditionFunctions(expr *_ConditionOperand, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	if expr.Not != nil {
-		collectConditionFunctions(expr.Not, children)
-	}
-	collectAdditionFunctions(expr.Left, children)
-	if expr.Right != nil {
-		collectAdditionFunctions(expr.Right.Right, children)
-	}
-}
-
-func collectAdditionFunctions(expr *_AdditionExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectMultiplicationFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		collectMultiplicationFunctions(term.Term, children)
-	}
-}
-
-func collectMultiplicationFunctions(expr *_MultiplicationExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectMemberFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		collectValueFunctions(term.Factor, children)
-	}
-}
-
-func collectMemberFunctions(expr *_MemberExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectValueFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		if term.Index != nil {
-			collectValueFunctions(term.Index, children)
-		}
-		if term.RangeEnd != nil {
-			collectValueFunctions(term.RangeEnd, children)
-		}
-	}
-}
-
-func collectValueFunctions(value *_Value, children *[]*OutlineInfo) {
-	if value == nil {
-		return
-	}
-	if value.SymbolRef != nil && value.SymbolRef.Called {
-		*children = append(*children, &OutlineInfo{
-			Name:   value.SymbolRef.Symbol,
-			Kind:   OutlineKindFunction,
-			Pos:    value.SymbolRef.Pos,
-			EndPos: value.SymbolRef.EndPos,
-		})
-	}
-	if value.Subexpression != nil {
-		collectCommaFunctions(value.Subexpression, children)
-	}
-}
-
-func collectCommaFunctions(expr *_CommaExpression, children *[]*OutlineInfo) {
-	if expr == nil {
-		return
-	}
-	collectAndFunctions(expr.Left, children)
-	for _, term := range expr.Right {
-		collectAndFunctions(term.Term, children)
-	}
-}
-
-func collectAndFunctions(expr *_AndExpression, children *[]*OutlineInfo) {
-	collectExpressionFunctions(expr, children)
+	return visitor.outlineRoot
 }

--- a/outline.go
+++ b/outline.go
@@ -70,7 +70,7 @@ type OutlineInfo struct {
 	// Children are nested symbols.
 	Children []*OutlineInfo
 
-	// isExpression marks the synthetic node the visitor creates for
+	// `isExpression` marks the synthetic node the visitor creates for
 	// a LET statement whose value is a plain expression rather than
 	// a query. Function calls are outlined beneath it just like they
 	// are beneath a column. This is an internal marker; callers never
@@ -94,8 +94,9 @@ func Outline(vql *VQL) *OutlineInfo {
 		CollectOutline: true,
 
 		// We only care about the outline, not the formatting.
-		// AnalysisOnly skips the formatter's look-ahead copies so
-		// the outline stack is maintained on the visitor itself.
+		// AnalysisOnly skips the look-ahead copies the formatter
+		// would make, so the outline stack is maintained on the
+		// visitor itself.
 		AnalysisOnly: true,
 	})
 	visitor.Visit(vql)

--- a/vfilter.go
+++ b/vfilter.go
@@ -208,7 +208,7 @@ var (
 )
 
 // droppingLexerDef wraps a lexer.Definition and drops tokens of the given
-// symbol names at the lexer level. This replicates the behaviour of
+// symbol names at the lexer level. This replicates the behavior of
 // participle v0.7.1's Elide() option, which was implemented as a lexer-level
 // Map that returned DropToken.
 type droppingLexerDef struct {

--- a/visitor.go
+++ b/visitor.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/participle/v2/lexer"
+
 	"www.velocidex.com/golang/vfilter/arg_parser"
 	"www.velocidex.com/golang/vfilter/materializer"
 	"www.velocidex.com/golang/vfilter/types"
@@ -54,23 +56,62 @@ type FormatOptions struct {
 	CollectDefinitionSites bool
 	CollectComments        bool
 
+	// CollectOutline makes the visitor build a document outline
+	// (an OutlineInfo tree) while it walks the AST. See Outline().
+	CollectOutline bool
+
+	// AnalysisOnly skips the formatter's look-ahead machinery so
+	// that every node is visited exactly once, on this visitor,
+	// rather than on throw-away copies. Analysis traversals
+	// (Inspect() and Outline()) need this because they maintain
+	// state - like the outline stack - across the whole tree.
+	AnalysisOnly bool
+
 	// Set when we do a test reformat to try to lookahead.
 	test bool
 }
 
 // The CallSite describes the place where a callable is called
 // from. For example, SELECT Foo(X=45) FROM scope()
+//
+// The position fields are populated when the visitor is used for
+// analysis (see Inspect()); consumers that only need the names
+// (Type/Name/Args) can ignore them.
 type CallSite struct {
 	Type string
 	Name string
 	Args []string
-}// The DefinitionSite describes where a function is declared:
+
+	// Pos/EndPos describe the span of the callable name (for bare
+	// symbols) or of the whole call including the closing paren (for
+	// functions and plugins).
+	Pos    lexer.Position
+	EndPos lexer.Position
+
+	// ArgPositions holds the source span of each argument in Args
+	// (parallel array). Populated for function and plugin calls.
+	ArgPositions []ArgPosition
+}
+
+// ArgPosition describes the source span of a single argument to a
+// function or plugin call.
+type ArgPosition struct {
+	Pos    lexer.Position
+	EndPos lexer.Position
+}
+
+// The DefinitionSite describes where a function is declared:
 // For example: LET Foo(X, Y) = ....
 type DefinitionSite struct {
 	Type     string
 	Name     string
 	Args     []string
 	Defaults []string
+
+	// Pos/EndPos describe the span of the LET statement. Populated
+	// when the visitor is used for analysis.
+	Pos    lexer.Position
+	EndPos lexer.Position
 }
 
 type Visitor struct {
@@ -110,6 +151,12 @@ type Visitor struct {
 	// Flag set when a comment is encountered.
 	has_comments bool
 
+	// Outline root and node stack, populated when opts.CollectOutline
+	// is set. The stack mirrors the nesting of LET statements, queries
+	// and columns as the visitor descends the AST.
+	outlineRoot  *OutlineInfo
+	outlineStack []*OutlineInfo
+
 	// Set via the VFILTER_DEBUG env.
 	debug bool
 }
@@ -121,6 +168,49 @@ func NewVisitor(scope types.Scope, options FormatOptions) *Visitor {
 		opts:        options,
 		indents:     []int{0},
 	}
+}
+
+// pushOutline adds an outline node as a child of the current node (or
+// as the root when the stack is empty) and makes it current.
+func (self *Visitor) pushOutline(node *OutlineInfo) {
+	if !self.opts.CollectOutline {
+		return
+	}
+	if len(self.outlineStack) > 0 {
+		parent := self.outlineStack[len(self.outlineStack)-1]
+		parent.Children = append(parent.Children, node)
+	} else {
+		self.outlineRoot = node
+	}
+	self.outlineStack = append(self.outlineStack, node)
+}
+
+// popOutline restores the previous outline node.
+func (self *Visitor) popOutline() {
+	if self.opts.CollectOutline && len(self.outlineStack) > 0 {
+		self.outlineStack = self.outlineStack[:len(self.outlineStack)-1]
+	}
+}
+
+// collectFunctionOutline records a function call as a child of the
+// current outline node when that node is one of the expression
+// containers (a SELECT column or a LET value). Calls inside a query's
+// FROM/WHERE clauses are intentionally not outlined - the outline
+// mirrors the SELECT column structure.
+func (self *Visitor) collectFunctionOutline(node *_SymbolRef) {
+	if len(self.outlineStack) == 0 {
+		return
+	}
+	parent := self.outlineStack[len(self.outlineStack)-1]
+	if parent.Kind != OutlineKindColumn && !parent.isExpression {
+		return
+	}
+	parent.Children = append(parent.Children, &OutlineInfo{
+		Name:   node.Symbol,
+		Kind:   OutlineKindFunction,
+		Pos:    node.Pos,
+		EndPos: node.EndPos,
+	})
 }
 
 // Merge results from the in visitor to this visitor.
@@ -419,6 +509,23 @@ func (self *Visitor) visitAliasedExpression(node *_AliasedExpression) {
 
 	self.Visit(node.Comments)
 
+	// Outline: each SELECT column becomes a "column" node in the
+	// document outline, holding any function calls in its expression
+	// as children. A column that is a subquery does not get its own
+	// node - the subquery's query node becomes the child directly.
+	if self.opts.CollectOutline && node.SubSelect == nil {
+		info := &OutlineInfo{
+			Kind:   OutlineKindColumn,
+			Pos:    node.Pos,
+			EndPos: node.EndPos,
+		}
+		if node.As != "" {
+			info.Name = node.As
+		}
+		self.pushOutline(info)
+		defer self.popOutline()
+	}
+
 	if node.Star != nil {
 		self.push("*")
 		return
@@ -515,8 +622,10 @@ func (self *Visitor) visitSymbolRef(node *_SymbolRef) {
 	self.push(node.Symbol)
 	if !node.Called && node.Parameters == nil {
 		callsite := CallSite{
-			Type: "symbol",
-			Name: node.Symbol,
+			Type:   "symbol",
+			Name:   node.Symbol,
+			Pos:    node.Pos,
+			EndPos: node.EndPos,
 		}
 
 		self.CallSites = append(self.CallSites, callsite)
@@ -525,15 +634,25 @@ func (self *Visitor) visitSymbolRef(node *_SymbolRef) {
 
 	if node.Called && self.opts.CollectCallSites {
 		callsite := CallSite{
-			Type: "function",
-			Name: node.Symbol,
+			Type:   "function",
+			Name:   node.Symbol,
+			Pos:    node.Pos,
+			EndPos: node.EndPos,
 		}
 
 		for _, p := range node.Parameters {
 			callsite.Args = append(callsite.Args,
 				utils.Unquote_ident(p.Left))
+			callsite.ArgPositions = append(callsite.ArgPositions,
+				ArgPosition{Pos: p.Pos, EndPos: p.EndPos})
 		}
 		self.CallSites = append(self.CallSites, callsite)
+	}
+
+	// Outline: called symbols inside a column (or a LET value) become
+	// function nodes in the document outline.
+	if node.Called && self.opts.CollectOutline {
+		self.collectFunctionOutline(node)
 	}
 
 	// No parameters anyway.
@@ -841,12 +960,16 @@ func (self *Visitor) visitPlugin(node *Plugin) {
 		// Collect callsites if needed.
 		if self.opts.CollectCallSites {
 			callsite := CallSite{
-				Type: "plugin",
-				Name: node.Name,
+				Type:   "plugin",
+				Name:   node.Name,
+				Pos:    node.Pos,
+				EndPos: node.EndPos,
 			}
 			for _, arg := range node.Args {
 				callsite.Args = append(callsite.Args,
 					utils.Unquote_ident(arg.Left))
+				callsite.ArgPositions = append(callsite.ArgPositions,
+					ArgPosition{Pos: arg.Pos, EndPos: arg.EndPos})
 			}
 			self.CallSites = append(self.CallSites, callsite)
 		}
@@ -956,6 +1079,22 @@ func (self *Visitor) visitSelectExpression(node *_SelectExpression) {
 
 func (self *Visitor) visitSelect(node *_Select) {
 	self.Visit(node.Comments)
+
+	// Outline: each SELECT statement (including subqueries) becomes a
+	// "query" node in the document outline, named after the FROM
+	// plugin.
+	if self.opts.CollectOutline {
+		info := &OutlineInfo{
+			Kind:   OutlineKindQuery,
+			Pos:    node.Pos,
+			EndPos: node.EndPos,
+		}
+		if node.From != nil && node.From.Plugin.Name != "" {
+			info.Name = node.From.Plugin.Name
+		}
+		self.pushOutline(info)
+		defer self.popOutline()
+	}
 
 	if node.Explain != nil {
 		self.push("EXPLAIN ")
@@ -1078,6 +1217,18 @@ func (self *Visitor) visitVQL(node *VQL) {
 	}()
 
 	if node.Let != "" {
+		// Outline: a LET statement becomes a "let" node in the
+		// document outline, with its value as a child.
+		if self.opts.CollectOutline {
+			self.pushOutline(&OutlineInfo{
+				Name:   node.Let,
+				Kind:   OutlineKindLet,
+				Pos:    node.Pos,
+				EndPos: node.EndPos,
+			})
+			defer self.popOutline()
+		}
+
 		operator := " = "
 		if node.LetOperator != "" {
 			operator = node.LetOperator
@@ -1091,9 +1242,11 @@ func (self *Visitor) visitVQL(node *VQL) {
 				self.push("(")
 				if self.opts.CollectDefinitionSites {
 					defsite := DefinitionSite{
-						Type: "definition",
-						Name: node.Let,
-						Args: []string{},
+						Type:   "definition",
+						Name:   node.Let,
+						Args:   []string{},
+						Pos:    node.Pos,
+						EndPos: node.EndPos,
 					}
 
 					for _, p := range parameters {
@@ -1127,8 +1280,10 @@ func (self *Visitor) visitVQL(node *VQL) {
 
 			} else if self.opts.CollectDefinitionSites {
 				defsite := DefinitionSite{
-					Type: "definition",
-					Name: node.Let,
+					Type:   "definition",
+					Name:   node.Let,
+					Pos:    node.Pos,
+					EndPos: node.EndPos,
 				}
 
 				if node.Called != "" {
@@ -1143,6 +1298,19 @@ func (self *Visitor) visitVQL(node *VQL) {
 		defer self.pop_indent()
 
 		if node.Expression != nil {
+			// Outline: a LET assigned a plain value gets a synthetic
+			// expression node so nested function calls can be outlined
+			// beneath it, mirroring the query structure.
+			if self.opts.CollectOutline {
+				self.pushOutline(&OutlineInfo{
+					Kind:         OutlineKindQuery,
+					Pos:          node.Expression.Pos,
+					EndPos:       node.Expression.EndPos,
+					isExpression: true,
+				})
+				defer self.popOutline()
+			}
+
 			self.Visit(node.Expression)
 			return
 		}
@@ -1165,6 +1333,17 @@ func (self *Visitor) abTest(
 	cbs ...func(self *Visitor),
 ) {
 	var res *Visitor
+
+	// Analysis-only traversals do not care about formatting. Visit
+	// the first alternative directly on this visitor so that analysis
+	// state (call sites, the outline stack) is collected exactly once
+	// on the real visitor instead of on throw-away copies.
+	if self.opts.AnalysisOnly {
+		if len(cbs) > 0 {
+			cbs[0](self)
+		}
+		return
+	}
 
 	if utils.IsDebug() {
 		fmt.Printf("%v: Performing abTest on %v\n", name, self.ToString())

--- a/visitor.go
+++ b/visitor.go
@@ -60,11 +60,12 @@ type FormatOptions struct {
 	// (an OutlineInfo tree) while it walks the AST. See Outline().
 	CollectOutline bool
 
-	// AnalysisOnly skips the formatter's look-ahead machinery so
-	// that every node is visited exactly once, on this visitor,
-	// rather than on throw-away copies. Analysis traversals
-	// (Inspect() and Outline()) need this because they maintain
-	// state - like the outline stack - across the whole tree.
+	// AnalysisOnly skips the look-ahead machinery the formatter
+	// uses, so that every node is visited exactly once, on this
+	// visitor, rather than on throw-away copies. Analysis
+	// traversals (Inspect() and Outline()) need this because they
+	// maintain state - like the outline stack - across the whole
+	// tree.
 	AnalysisOnly bool
 
 	// Set when we do a test reformat to try to lookahead.
@@ -512,7 +513,8 @@ func (self *Visitor) visitAliasedExpression(node *_AliasedExpression) {
 	// Outline: each SELECT column becomes a "column" node in the
 	// document outline, holding any function calls in its expression
 	// as children. A column that is a subquery does not get its own
-	// node - the subquery's query node becomes the child directly.
+	// node - the query node of the subquery becomes the child
+	// directly.
 	if self.opts.CollectOutline && node.SubSelect == nil {
 		info := &OutlineInfo{
 			Kind:   OutlineKindColumn,


### PR DESCRIPTION
Fold the duplicated AST descent logic from inspect.go and outline.go into the existing Visitor so the grammar is traversed by a single mechanism.

The Visitor now supports two additional format options:

- AnalysisOnly: bypasses the copy/merge bookkeeping used by the formatter path so analysis state is collected exactly once on the original node graph.
- CollectOutline: enables outline construction via an explicit stack that builds the Let/Query/Column/Function hierarchy. Function nodes are only emitted under column or expression contexts, so FROM, WHERE and GROUP BY clauses do not pollute the outline.

Source positions are recorded on CallSite (including per-argument positions) and DefinitionSite. The existing string-based Args field is retained unchanged, preserving backwards compatibility for consumers such as the launcher verifier.

Inspect() and Outline() are now thin wrappers that configure a Visitor, run a single traversal, and translate the collected state into their existing exported types; no caller-facing API changes. This removes roughly 410 lines of duplicated traversal code while keeping the full test suite (including the Velociraptor LSP integration tests) green.